### PR TITLE
Patch RELOC_REL32 cases where offset is > 2GiB

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Next version
+- -base option consistently applied to mingw64, cygwin64 and msvc64. Default is
+  no longer specified (David Allsopp)
+
 Version 0.37
 - Bug fix: the IMAGE_SCN_LNK_NRELOC_OVFL section flag was not propertly reset when
   the number of relocations was reduced enough to fit in the 16-bit field,

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Next version
 - -base option consistently applied to mingw64, cygwin64 and msvc64. Default is
   no longer specified (David Allsopp)
+- 64-bit ports can now always process RELOC_REL32* relocations by generating
+  trampolines for cases where the relocations are more than 32GiB away. New
+  functionality passed as flexdll_relocate_v2, which allows mixing executables
+  and DLLs compiled with and without the new features. If either executable or
+  DLL lacks the flexdll_relocate_v2 support, then it falls back to the previous
+  error message if a RELOC_REL32 is more than 2GiB away. (David Allsopp)
 
 Version 0.37
 - Bug fix: the IMAGE_SCN_LNK_NRELOC_OVFL section flag was not propertly reset when

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -119,4 +119,6 @@ git remote add local $(echo "$APPVEYOR_BUILD_FOLDER"| cygpath -f -) -f --tags
 run "git checkout $APPVEYOR_REPO_COMMIT" git checkout merge
 cd ..
 
+mv $OCAMLROOT $OCAMLROOT-Disabled
 run "make world" $MAKEOCAML flexdll world
+mv $OCAMLROOT-Disabled $OCAMLROOT

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -109,6 +109,11 @@ fi
 
 configure_ocaml full
 
+# This tortures the ocamldoc compilation as it means that dllcamlstr,
+# dllunix and ocamlrun will all be more than 2GiB apart.
+sed -i -e "s/^LDOPTS=.*/\0 -ldopt -base -ldopt 0x210000000/" otherlibs/win32unix/Makefile
+sed -i -e "/^include \.\.\/Makefile/aLDOPTS=-ldopt -base -ldopt 0x310000000" otherlibs/str/Makefile
+
 cd flexdll
 git remote add local $(echo "$APPVEYOR_BUILD_FOLDER"| cygpath -f -) -f --tags
 run "git checkout $APPVEYOR_REPO_COMMIT" git checkout merge

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -45,7 +45,7 @@ let implib = ref false
 let deffile = ref None
 let stack_reserve = ref None
 let no_rel_relocs = ref false
-let base_addr = ref "0x10000"
+let base_addr = ref None
 
 let usage_msg =
   Printf.sprintf
@@ -86,7 +86,7 @@ let specs = [
   "-norelrelocs", Arg.Set no_rel_relocs,
   " Ensure that no relative relocation is generated";
 
-  "-base", Arg.String (fun s -> base_addr := s),
+  "-base", Arg.String (fun s -> base_addr := Some s),
   " Specify base address (Win64 only)";
 
   "-I", Arg.String (fun dir -> dirs := dir :: !dirs),

--- a/flexdll.c
+++ b/flexdll.c
@@ -257,7 +257,7 @@ retry:
           void* trampoline;
           /* trampolines cannot be created for data */
           if (VirtualQuery(sym->addr, &info, sizeof(info)) && !(info.Protect & 0xf0)) {
-            sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32%s, target is too far, and not executable: %p  %p", reloc_type, (void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
+            sprintf(error_buffer, "flexdll error: cannot relocate %s via RELOC_REL32%s, target is too far, and not executable: %p  %p", ptr->name, reloc_type, (void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
             error = 3;
             return;
           }

--- a/flexdll.c
+++ b/flexdll.c
@@ -263,7 +263,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl, void **jmptbl) {
             *((UINT_PTR*)((char*)trampoline + 7)) = (UINT_PTR)sym->addr;
             /* Pad with nop */
             *(((char*)trampoline + 15)) = 0x90;
-            *((char*)jmptbl) += 16;
+            *((UINT_PTR*)jmptbl) += 16;
           }
           s = (UINT_PTR)(sym->trampoline);
           s -= (INT_PTR)(ptr->addr) + rel_offset;

--- a/flexdll.c
+++ b/flexdll.c
@@ -252,10 +252,10 @@ static void relocate(resolver f, void *data, reloctbl *tbl, void **jmptbl) {
             void* trampoline = sym->trampoline = *jmptbl;
             /* movq $(sym->addr), %rax */
             *((short*)trampoline) = 0xb848;
-            *((UINT_PTR*)(trampoline + 2)) = (UINT_PTR)sym->addr;
+            *((UINT_PTR*)((char*)trampoline + 2)) = (UINT_PTR)sym->addr;
             /* jmp %rax */
-            *((short*)(trampoline + 10)) = 0xe0ff;
-            *jmptbl += 16;
+            *((short*)((char*)trampoline + 10)) = 0xe0ff;
+            *((char*)jmptbl) += 16;
           }
           s = (UINT_PTR)(sym->trampoline);
           s -= (INT_PTR)(ptr->addr) + rel_offset;

--- a/flexdll.c
+++ b/flexdll.c
@@ -257,11 +257,12 @@ static void relocate(resolver f, void *data, reloctbl *tbl, void **jmptbl) {
               return;
             }
             trampoline = sym->trampoline = *jmptbl;
-            /* movq $(sym->addr), %rax */
-            *((short*)trampoline) = 0xb848;
-            *((UINT_PTR*)((char*)trampoline + 2)) = (UINT_PTR)sym->addr;
-            /* jmp %rax */
-            *((short*)((char*)trampoline + 10)) = 0xe0ff;
+            /* rex.W jmpq $0x0(%rip) */
+            *((__int64*)trampoline) = 0x25ff48;
+            /* Place the actual symbol immediately after the instruction */
+            *((UINT_PTR*)((char*)trampoline + 7)) = (UINT_PTR)sym->addr;
+            /* Pad with nop */
+            *(((char*)trampoline + 15)) = 0x90;
             *((char*)jmptbl) += 16;
           }
           s = (UINT_PTR)(sym->trampoline);

--- a/flexdll_initer.c
+++ b/flexdll_initer.c
@@ -22,24 +22,32 @@ typedef int func(void*);
 typedef int func_v2(void*,void*);
 
 extern int reloctbl;
+#if defined(_WIN64) || defined(__CYGWIN64__)
 extern int jmptbl;
+#endif
 
 static int flexdll_init() {
   func *sym = 0;
   func_v2 *sym_v2 = 0;
-  char *s = getenv("FLEXDLL_RELOCATE_V2");
   /* If the supplied symbol is NULL, treat as "loaded not for execution" */
+#if defined(_WIN64) || defined(__CYGWIN64)
+  char *s = getenv("FLEXDLL_RELOCATE_V2");
   if (!s) {
+#else
+  char *s;
+#endif
     s = getenv("FLEXDLL_RELOCATE");
     if (!s) { fprintf(stderr, "Cannot find FLEXDLL_RELOCATE\n"); return FALSE; }
     /* The executable image doesn't support the V2 interface, so RELOC_REL32
        may fail. */
     sscanf(s, "%p", &sym);
     if (!sym || sym(&reloctbl)) return TRUE;
+#if defined(_WIN64) || defined(__CYGWIN64)
   } else {
     sscanf(s, "%p", &sym_v2);
     if (!sym_v2 || sym_v2(&reloctbl, &jmptbl)) return TRUE;
   }
+#endif
   return FALSE;
 }
 

--- a/reloc.ml
+++ b/reloc.ml
@@ -1007,7 +1007,9 @@ let build_dll link_exe output_file files exts extra_args =
         in
 
         let extra_args =
-          if !machine = `x64 then (Printf.sprintf "/base:%s " !base_addr) ^ extra_args else extra_args
+          match !machine, !base_addr with
+          | `x64, Some base_addr -> Printf.sprintf "/base:%s %s" base_addr extra_args
+          | _ -> extra_args
         in
         (* Flexdll requires that all images (main programs and all the DLLs) are
            not too far away. This is needed because of the 32-bit relative relocations
@@ -1044,7 +1046,9 @@ let build_dll link_exe output_file files exts extra_args =
             Filename.quote def_file
         in
         let extra_args =
-          if !machine = `x64 then "-Xlinker --image-base -Xlinker 0x10000 " ^ extra_args else extra_args
+          match !machine, !base_addr with
+          | `x64, Some base_addr -> Printf.sprintf "-Xlinker --image-base -Xlinker %s %s" base_addr extra_args
+          | _ -> extra_args
         in
         Printf.sprintf
           "%s %s%s -L. %s %s -o %s %s %s %s %s"
@@ -1066,6 +1070,11 @@ let build_dll link_exe output_file files exts extra_args =
             Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n";
             close_out oc;
             Filename.quote def_file
+        in
+        let extra_args =
+          match !machine, !base_addr with
+          | `x64, Some base_addr -> Printf.sprintf "-Xlinker --image-base -Xlinker %s %s" base_addr extra_args
+          | _ -> extra_args
         in
         Printf.sprintf
           "%s -m%s %s%s -L. %s %s -o %s %s %s %s %s %s"

--- a/reloc.ml
+++ b/reloc.ml
@@ -753,7 +753,7 @@ let build_dll link_exe output_file files exts extra_args =
     List.iter (fun fn -> collect_file (find_file fn)) exts;
 
     if main_pgm then add_def (usym "static_symtable")
-    else (add_def (usym "reloctbl"); add_def (usym "jmptbl"));
+    else (add_def (usym "reloctbl"); if !machine = `x64 then add_def (usym "jmptbl"));
 
     if !machine = `x64 then add_def "__ImageBase"
     else add_def "___ImageBase";
@@ -936,7 +936,8 @@ let build_dll link_exe output_file files exts extra_args =
     (usym (if main_pgm then "static_symtable" else "symtbl"));
   if not main_pgm then begin
     add_master_reloc_table obj !reloctbls (usym "reloctbl");
-    add_master_jmp_table obj !trampolines (usym "jmptbl");
+    if !machine = `x64 then
+      add_master_jmp_table obj !trampolines (usym "jmptbl");
   end;
 
   if !errors then
@@ -1029,10 +1030,11 @@ let build_dll link_exe output_file files exts extra_args =
            with the Windows 7 SDK in 64-bit mode. *)
 
         Printf.sprintf
-          "link /nologo %s%s%s%s%s /implib:%s /out:%s /subsystem:%s %s %s %s"
+          "link /nologo %s%s%s%s%s%s /implib:%s /out:%s /subsystem:%s %s %s %s"
           (if !verbose >= 2 then "/verbose " else "")
           (if link_exe = `EXE then "" else "/dll ")
-          (if main_pgm then "" else "/export:symtbl /export:reloctbl /export:jmptbl ")
+          (if main_pgm then "" else "/export:symtbl /export:reloctbl ")
+          (if main_pgm || !machine = `x86 then "" else "/export:jmptbl ")
           (if main_pgm then "" else if !noentry then "/noentry " else
           let s =
             match !machine with
@@ -1052,7 +1054,9 @@ let build_dll link_exe output_file files exts extra_args =
           if main_pgm then ""
           else
             let def_file, oc = open_temp_file "flexlink" ".def" in
-            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n  jmptbl\n";
+            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n";
+            if !machine = `x64 then
+              Printf.fprintf oc "  jmptbl\n";
             close_out oc;
             Filename.quote def_file
         in
@@ -1078,7 +1082,9 @@ let build_dll link_exe output_file files exts extra_args =
           if main_pgm then ""
           else
             let def_file, oc = open_temp_file "flexlink" ".def" in
-            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n  jmptbl\n";
+            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n";
+            if !machine = `x64 then
+              Printf.fprintf oc "  jmptbl\n";
             close_out oc;
             Filename.quote def_file
         in

--- a/reloc.ml
+++ b/reloc.ml
@@ -358,7 +358,7 @@ module StrSet = Set.Make(String)
    by their name). It also lists segments that are normally write-protected
    and that must be de-protected to enable the patching process. *)
 
-let add_reloc_table obj obj_name p =
+let add_reloc_table obj obj_name p trampolines =
   let sname = Symbol.gen_sym () in (* symbol pointing to the reloc table *)
   let sect = Section.create ".reltbl" 0xc0300040l in
   let data = Buffer.create 1024 in
@@ -376,22 +376,22 @@ let add_reloc_table obj obj_name p =
   let reloc secsym min max rel =
     if p rel.symbol then (
       (* kind *)
-      let kind = match !machine, rel.rtype with
+      let kind, may_trampoline = match !machine, rel.rtype with
         | `x86, 0x06 (* IMAGE_REL_I386_DIR32 *)
         | `x64, 0x01 (* IMAGE_REL_AMD64_ADDR64 *) ->
-            0x0002 (* absolute, native size (32/64) *)
+            0x0002, false (* absolute, native size (32/64) *)
 
         | `x64, 0x04 (* IMAGE_REL_AMD64_REL32 *)
         | `x86, 0x14 (* IMAGE_REL_I386_REL32 *) when not !no_rel_relocs ->
-            0x0001 (* rel32 *)
+            0x0001, true (* rel32 *)
 
-        | `x64, 0x05 when not !no_rel_relocs -> 0x0004 (* rel32_1 *)
-        | `x64, 0x08 when not !no_rel_relocs-> 0x0003 (* rel32_4 *)
-        | `x64, 0x06 when not !no_rel_relocs-> 0x0005 (* rel32_2 *)
+        | `x64, 0x05 when not !no_rel_relocs -> 0x0004, true (* rel32_1 *)
+        | `x64, 0x08 when not !no_rel_relocs-> 0x0003, true (* rel32_4 *)
+        | `x64, 0x06 when not !no_rel_relocs-> 0x0005, true (* rel32_2 *)
 
         | `x86, (0x0a (* IMAGE_REL_I386_SECTION *) |
                  0x0b (* IMAGE_REL_I386_SECREL*) ) ->
-            0x0100 (* debug relocs: ignore *)
+            0x0100, false (* debug relocs: ignore *)
 
         | _, k  ->
             let msg =
@@ -402,6 +402,7 @@ let add_reloc_table obj obj_name p =
 (*            Printf.eprintf "%s\n" msg;
             0x0001 *)
       in
+      if may_trampoline then trampolines := StrSet.add rel.symbol.sym_name !trampolines;
       int_to_buf data kind;
 
       (* name *)
@@ -538,6 +539,12 @@ let add_master_reloc_table obj names symname =
   sect.data <- `String (Buffer.to_bytes data);
   obj.sections <- sect :: obj.sections
 
+let add_master_jmp_table obj names symname =
+  let trampolines = StrSet.cardinal names in
+  let sect = Section.create ".mjmptbl" 0xe0500020l in
+  obj.symbols <- (Symbol.export symname sect 0l) :: obj.symbols;
+  sect.data <- `Uninit (trampolines * 16);
+  obj.sections <- sect :: obj.sections
 
 
 let collect_dllexports obj =
@@ -746,7 +753,7 @@ let build_dll link_exe output_file files exts extra_args =
     List.iter (fun fn -> collect_file (find_file fn)) exts;
 
     if main_pgm then add_def (usym "static_symtable")
-    else add_def (usym "reloctbl");
+    else (add_def (usym "reloctbl"); add_def (usym "jmptbl"));
 
     if !machine = `x64 then add_def "__ImageBase"
     else add_def "___ImageBase";
@@ -801,6 +808,7 @@ let build_dll link_exe output_file files exts extra_args =
 
   let libobjects  = Hashtbl.create 16 in
   let reloctbls = ref [] in
+  let trampolines = ref StrSet.empty in
   let exported = ref StrSet.empty in
 
   List.iter (fun s -> exported := StrSet.add (usym s) !exported) !defexports;
@@ -821,7 +829,7 @@ let build_dll link_exe output_file files exts extra_args =
       Printf.printf "** Imported symbols for %s:\n" name;
       StrSet.iter print_endline imps
     );
-    let sym = add_reloc_table obj name (fun s -> StrSet.mem s.sym_name imps) in
+    let sym = add_reloc_table obj name (fun s -> StrSet.mem s.sym_name imps) trampolines in
     reloctbls := sym :: !reloctbls
   in
 
@@ -926,7 +934,10 @@ let build_dll link_exe output_file files exts extra_args =
 
   add_export_table obj (if !noexport then [] else StrSet.elements !exported)
     (usym (if main_pgm then "static_symtable" else "symtbl"));
-  if not main_pgm then add_master_reloc_table obj !reloctbls (usym "reloctbl");
+  if not main_pgm then begin
+    add_master_reloc_table obj !reloctbls (usym "reloctbl");
+    add_master_jmp_table obj !trampolines (usym "jmptbl");
+  end;
 
   if !errors then
     exit 2;
@@ -1021,7 +1032,7 @@ let build_dll link_exe output_file files exts extra_args =
           "link /nologo %s%s%s%s%s /implib:%s /out:%s /subsystem:%s %s %s %s"
           (if !verbose >= 2 then "/verbose " else "")
           (if link_exe = `EXE then "" else "/dll ")
-          (if main_pgm then "" else "/export:symtbl /export:reloctbl ")
+          (if main_pgm then "" else "/export:symtbl /export:reloctbl /export:jmptbl ")
           (if main_pgm then "" else if !noentry then "/noentry " else
           let s =
             match !machine with
@@ -1041,7 +1052,7 @@ let build_dll link_exe output_file files exts extra_args =
           if main_pgm then ""
           else
             let def_file, oc = open_temp_file "flexlink" ".def" in
-            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n";
+            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n  jmptbl\n";
             close_out oc;
             Filename.quote def_file
         in
@@ -1067,7 +1078,7 @@ let build_dll link_exe output_file files exts extra_args =
           if main_pgm then ""
           else
             let def_file, oc = open_temp_file "flexlink" ".def" in
-            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n";
+            Printf.fprintf oc "EXPORTS\n  reloctbl\n  symtbl\n  jmptbl\n";
             close_out oc;
             Filename.quote def_file
         in


### PR DESCRIPTION
Previously, if a DLL was loaded more than 2GiB away from the executable image in the address space, flexdll_relocate would fail if there were any RELOC_REL32 relocations as the offset couldn't be represented in a 32-bit number.

The solution at the time was to specify a base address of 0x10000 for the MSVC64 and Cygwin64 ports (for some reason, mingw64 got forgotten about). For MSVC64, this generally seemed to work. For Cygwin64, this broke Unix.fork. Recent changes to Cygwin64 also mean that Cygwin DLLs and executables are not supposed to occupy memory below `0x2:00000000` and `0x1:00000000` respectively.

This patch creates a spare executable section in the DLL which is used to create trampolines for relocations where the offset is over 2GiB. As a result, it's no longer necessary to specify the image base address, so this default has been removed and both the Cygwin64 fork issue and RELOC_REL32 are simultaneously solved.

This needs quite a lot of testing which I'm doing, but it would also be handy for the code to start being reviewed. The easiest option would have been to break backwards compatibility (format of `symtbl` would have changed and the number of parameters for `flexdll_relocate`). The version I give here allows mixing of DLLs and executables compiled with both this new version and older versions.