### PR TITLE
Add "incbin" functionality

### DIFF
--- a/cmdline.ml
+++ b/cmdline.ml
@@ -37,6 +37,7 @@ let output_file = ref ""
 let exe_mode : [`DLL | `EXE | `MAINDLL] ref = ref `DLL
 let extra_args = ref []
 let mode : [`NORMAL | `DUMP | `PATCH] ref = ref `NORMAL
+let incbins = ref []
 let defexports = ref []
 let noentry = ref false
 let use_cygpath = ref true
@@ -71,6 +72,13 @@ let specs = [
 
   "-exe", Arg.Unit (fun () -> exe_mode := `EXE),
   " Link the main program as an exe file";
+
+  "-incbin",
+  Arg.Tuple
+   (let r = ref "" in
+    [Arg.Set_string r;
+     Arg.String (fun s -> incbins := (!r, s) :: !incbins)]),
+  "<sym> <file> Include a binary blob";
 
   "-maindll", Arg.Unit (fun () -> exe_mode := `MAINDLL),
   " Link the main program as a dll file";


### PR DESCRIPTION
This PR adds an "incbin" (see https://github.com/graphitemaster/incbin) feature to `flexdll`, allowing to include binary blobs in the final binary. The motivation is https://github.com/ocaml/ocaml/pull/10159 and https://github.com/ocaml/ocaml/pull/10654, namely including debug information for bytecode binaries built with `--output-complete-exe` with MSVC, but the functionality makes sense independently.

Concretely, a new flag `-incbin <sym> <file>` is added which has the effect of embedding `<file>` inside the final binary and defining two symbols: `<sym>_data` and `<sym>_size`: `<sym>_data` points to the beginning of the binary blob, and `<sym>_size` is a 32-bit int containing the size of the binary blob.

I'm still testing it, but feedback would be welcome!