### PR TITLE
Remove the `Lazy` infrastructure from `Coff`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Next version
+- GPR#103: Delete objects from C files compiled by flexlink (David Allsopp, report by Xavier Leroy)
+
 Version 0.41
 - GPR#98: Eliminate Warning 6 compiling coff.ml (David Allsopp)
 - GPR#99: Harden version number parsing from ocamlopt -version (David Allsopp)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,8 @@ install:
   # cygpath behaves crazily), but after the MSVC one.
   - set Path=C:\cygwin\bin;%OCAMLROOT%\bin;C:\flexdll;%Path%
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - if exist "%CYG_ROOT%\setup-x86.exe" del "%CYG_ROOT%\setup-x86.exe"
+  - appveyor DownloadFile "https://cygwin.com/setup-x86.exe" -FileName "%CYG_ROOT%\setup-x86.exe"
   - '"%CYG_ROOT%\setup-x86.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages cygwin64-gcc-core,unzip,zip > nul'
   - '%CYG_ROOT%\bin\bash -lc "x86_64-pc-cygwin-gcc --version" > nul || "%CYG_ROOT%\setup-x86.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul'
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -103,7 +103,7 @@ case $OCAMLBRANCH in
     FLEXDLL_BOOTSTRAP_WORKS=0;;
   4.09|4.10|4.11|4.12)
     FLEXDLL_BOOTSTRAP_WORKS=0;;
-  5.0|5.00)
+  5.0|5.00|5.1)
     case "$OCAML_PORT" in
       mingw)
         export PATH="$PATH:/usr/i686-w64-mingw32/sys-root/mingw/bin";;

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -16,9 +16,11 @@ function run {
 
 function configure_ocaml {
     if [[ -z $HEADER_DIR ]] ; then
-      # Unfortunately, configure fails to set-up bootstrapping if flexlink is
-      # in PATH
-      sed -i -e 's/@iflexdir@/-I"$(ROOTDIR)\/flexdll"/' Makefile.config.in
+      if [[ $FLEXDLL_BOOTSTRAP_WORKS -eq 0 ]]; then
+        # Unfortunately, configure fails to set-up bootstrapping if flexlink is
+        # in PATH
+        sed -i -e 's/@iflexdir@/-I"$(ROOTDIR)\/flexdll"/' Makefile.config.in
+      fi
 
       ./configure --build=i686-pc-cygwin --host=$OCAML_TARGET \
                     --prefix=$OCAMLROOT \
@@ -86,6 +88,7 @@ MAKEOCAML=make
 CONFIG_DIR=config
 GRAPHICS_DISABLE=
 HEADER_DIR=
+FLEXDLL_BOOTSTRAP_WORKS=1
 
 case $OCAMLBRANCH in
   3.11|3.12|4.00|4.01|4.02|4.03|4.04)
@@ -96,7 +99,10 @@ case $OCAMLBRANCH in
   4.06|4.07)
     HEADER_DIR=byterun/caml;;
   4.08)
-    GRAPHICS_DISABLE=--disable-graph-lib;;
+    GRAPHICS_DISABLE=--disable-graph-lib
+    FLEXDLL_BOOTSTRAP_WORKS=0;;
+  4.09|4.10|4.11|4.12)
+    FLEXDLL_BOOTSTRAP_WORKS=0;;
   5.0|5.00)
     case "$OCAML_PORT" in
       mingw)

--- a/create_dll.ml
+++ b/create_dll.ml
@@ -34,10 +34,9 @@ let discard_section s =
  ||| 0x02000000l) <> 0l (* Discardable *)
 
 let sect_data s =
-  match force_section_data s with
+  match s.data with
   | `String data -> data
   | `Buf _ -> assert false
-  | `Lazy _ -> assert false
   | `Sxdata _ -> assert false
   | `Uninit 0 -> Bytes.of_string ""
   | `Uninit size ->


### PR DESCRIPTION
It hasn't been being used for 15 years, but `Lib.read` still left the channel open to allow for it. This meant that objects created by flexdll (from compiling a C file passed on the command line) would not be deleted on completion.