### PR TITLE
Add -lgcc_s to Cygwin link libraries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
 Next version
+- GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the
+  Cygwin flexdll package (David Allsopp)
+
+Version 0.42
 - GPR#106: Support -l: syntax, to allow static linking of specific libraries (David Allsopp)
 - GPR#103: Delete objects from C files compiled by flexlink (David Allsopp, report by Xavier Leroy)
 - GPR#85: Split multiple arguments passed with a single -Wl (David Allsopp)

--- a/reloc.ml
+++ b/reloc.ml
@@ -1300,7 +1300,7 @@ let setup_toolchain () =
            Filename.dirname (get_output1 ~use_bash:true "gcc -print-libgcc-file-name");
           ];
       default_libs := ["-lkernel32"; "-luser32"; "-ladvapi32";
-                       "-lshell32"; "-lcygwin"; "-lgcc"]
+                       "-lshell32"; "-lcygwin"; "-lgcc_s"; "-lgcc"]
   | `MSVC | `MSVC64 ->
       search_path := !dirs @
         parse_libpath (try Sys.getenv "LIB" with Not_found -> "");


### PR DESCRIPTION
Related to the `-lgcc_eh` change in #48 for mingw-w64. This patch has been carried in Cygwin itself for a long time - it is critical for OCaml 5.x, so let's finally upstream it.