### PR TITLE
Fix source package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ package_src:
 	rm -Rf flexdll-$(VERSION)
 	mkdir flexdll-$(VERSION)
 	mkdir flexdll-$(VERSION)/test
-	cp -a $(filter-out Compat.ml version.ml,$(OBJS) $(shell git ls-files Compat*.ml)) Makefile msvs-detect $(COMMON_FILES) version.rc flexdll-$(VERSION)/
+	cp -a $(filter-out version.ml,$(OBJS:Compat.ml=Compat.ml.in)) Makefile msvs-detect $(COMMON_FILES) version.rc flexdll-$(VERSION)/
 	cp -aR test/Makefile test/*.c flexdll-$(VERSION)/test/
 	tar czf $(PACKAGE) flexdll-$(VERSION)
 	rm -Rf flexdll-$(VERSION)


### PR DESCRIPTION
#85's overhaul of the compatibility layer meant that the `package_src` target builds a tarball which doesn't include the required `Compat.ml.in`. We use the GH tarball on the releases, so it's not critical, but it may as well be correct.