### PR TITLE
Cosmetic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.cmo
 *.cmi
 *.dll
+*.tar.gz
+*.zip
 flexlink.exe
 flexlink.opt
 test/dump.exe

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The package FlexDLL is released under the terms of a zlib/libpng License.
+The package FlexDLL is released under the terms of the zlib/libpng License.
 
 Copyright (c) 2007, 2008, 2009
 Institut National de Recherche en Informatique et en Automatique
@@ -11,13 +11,12 @@ Permission is granted to anyone to use this software for any purpose,
 including commercial applications, and to alter it and redistribute it
 freely, subject to the following restrictions:
 
-    1. The origin of this software must not be misrepresented; you must not
-    claim that you wrote the original software. If you use this software
-    in a product, an acknowledgment in the product documentation would be
-    appreciated but is not required.
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
 
-    2. Altered source versions must be plainly marked as such, and must not be
-    misrepresented as being the original software.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
 
-    3. This notice may not be removed or altered from any source
-    distribution.
+3. This notice may not be removed or altered from any source distribution.

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@
 VERSION = 0.42
 all: flexlink.exe support
 
-OCAML_CONFIG_FILE=$(shell cygpath -ad "$(shell ocamlopt -where)/Makefile.config")
+OCAML_CONFIG_FILE=$(shell cygpath -ad "$(shell ocamlopt -where 2>/dev/null)/Makefile.config" 2>/dev/null)
 include $(OCAML_CONFIG_FILE)
 OCAMLOPT=ocamlopt
 EMPTY=
 SPACE=$(EMPTY) $(EMPTY)
-OCAML_VERSION:=$(firstword $(subst ~, ,$(subst +, ,$(shell $(OCAMLOPT) -version))))
+OCAML_VERSION:=$(firstword $(subst ~, ,$(subst +, ,$(shell $(OCAMLOPT) -version 2>/dev/null))))
 ifeq ($(OCAML_VERSION),)
 OCAML_VERSION:=0
 COMPAT_VERSION:=0

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -214,6 +214,18 @@ let specs = [
 
   "--", Arg.Rest (fun s -> extra_args := s :: !extra_args),
   " Following arguments are passed verbatim to the linker";
+
+  "-version", Arg.Unit
+    (fun () ->
+      Printf.printf "FlexDLL version %s\nFlexDLL directory: %s\n"
+                    Version.version
+                    (Filename.dirname Sys.executable_name);
+      exit 0
+    ),
+  " Print linker version and FlexDLL directory and exit";
+
+  "-vnum", Arg.Unit (fun () -> print_endline Version.version; exit 0),
+  " Print linker version number and exit";
 ]
 
 

--- a/version.rc
+++ b/version.rc
@@ -22,6 +22,10 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileVersion", "0.0.0.42"
+            VALUE "ProductVersion", "0.0.0.42"
+            VALUE "ProductName", "FlexDLL"
+            VALUE "FileDescription", "FlexDLL Linker"
+            VALUE "LegalCopyright", "Institut National de Recherche en Informatique et en Automatique"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
- Eliminate spurious error messages when `ocamlopt` isn't available in the environment
- Missing `.gitignore` patterns for release tarballs and zips
- Tidy up `LICENSE` file
- Add additional fields to the version information block in `flexlink.exe`
- Add a `-vnum` and `-version` command line argument (finally)