### PR TITLE
opam packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@
 ##
 
 
-VERSION = 0.42
+VERSION = \
+  $(eval VERSION := $$(shell sed -ne 's/^version: *"\(.*\)"/\1/p' flexdll.opam))$(VERSION)
+
 all: flexlink.exe support
 
 OCAML_CONFIG_FILE=$(shell cygpath -ad "$(shell ocamlopt -where 2>/dev/null)/Makefile.config" 2>/dev/null)
@@ -164,11 +166,25 @@ flexlink.exe: $(OBJS) $(RES)
 	rm -f flexlink.exe
 	$(RES_PREFIX) $(OCAMLOPT) -o flexlink.exe $(LINKFLAGS) $(OBJS)
 
-version.res: version.rc
-	$(RES_PREFIX) rc version.rc
+COMMA = ,
+FULL_VERSION = $(wordlist 1, 4, $(subst ., ,$(VERSION)) 0 0 0)
+FLEXDLL_VERSION = $(subst $(SPACE),$(COMMA),$(FULL_VERSION))
+FLEXDLL_VERSION_STR = $(subst $(SPACE),.,$(FULL_VERSION))
 
-version_res.o: version.rc
-	$(TOOLPREF)windres version.rc version_res.o
+RC_FLAGS = \
+  /d FLEXDLL_VERSION=$(FLEXDLL_VERSION) \
+  /d FLEXDLL_VERSION_STR="$(FLEXDLL_VERSION_STR)"
+
+# cf. https://sourceware.org/bugzilla/show_bug.cgi?id=27843
+WINDRES_FLAGS = \
+  -D FLEXDLL_VERSION=$(FLEXDLL_VERSION) \
+  -D FLEXDLL_VERSION_STR=\\\"$(FLEXDLL_VERSION_STR)\\\"
+
+version.res: version.rc flexdll.opam
+	$(RES_PREFIX) rc /nologo $(RC_FLAGS) $<
+
+version_res.o: version.rc flexdll.opam
+	$(TOOLPREF)windres $(WINDRES_FLAGS) $< $@
 
 flexdll_msvc.obj: flexdll.h flexdll.c
 	$(MSVC_PREFIX) $(MSVCC) /DMSVC -c /Fo"flexdll_msvc.obj" flexdll.c
@@ -252,7 +268,7 @@ package_src:
 	rm -Rf flexdll-$(VERSION)
 	mkdir flexdll-$(VERSION)
 	mkdir flexdll-$(VERSION)/test
-	cp -a $(filter-out version.ml,$(OBJS:Compat.ml=Compat.ml.in)) Makefile msvs-detect $(COMMON_FILES) version.rc flexdll-$(VERSION)/
+	cp -a $(filter-out version.ml,$(OBJS:Compat.ml=Compat.ml.in)) Makefile msvs-detect $(COMMON_FILES) version.rc flexdll.install flexdll.opam flexdll-$(VERSION)/
 	cp -aR test/Makefile test/*.c flexdll-$(VERSION)/test/
 	tar czf $(PACKAGE) flexdll-$(VERSION)
 	rm -Rf flexdll-$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -284,13 +284,14 @@ upload_src: package_src upload
 # Binary package
 
 PACKAGE_BIN = flexdll-bin-$(VERSION)$(PACKAGE_BIN_SUFFIX).zip
+FLEXLINK_BIN = flexlink-bin-$(VERSION)$(PACKAGE_BIN_SUFFIX).zip
 INSTALLER = flexdll-$(VERSION)$(PACKAGE_BIN_SUFFIX)-setup.exe
 
 package_bin:
 	$(MAKE) clean all
-	rm -f $(PACKAGE_BIN)
-	zip $(PACKAGE_BIN) $(COMMON_FILES) \
-	    flexlink.exe flexdll_*.obj flexdll_*.o flexdll.c flexdll_initer.c
+	rm -f $(PACKAGE_BIN) $(FLEXLINK_BIN)
+	zip $(PACKAGE_BIN) $(COMMON_FILES) flexlink.exe flexdll_*.obj flexdll_*.o
+	zip $(FLEXLINK_BIN) $(COMMON_FILES) flexlink.exe Makefile flexdll-bin.install flexdll-bin.opam
 
 do_upload_bin:
 	rsync $(PACKAGE_BIN) $(URL)

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -202,10 +202,12 @@ if [ "$ARTEFACTS" = 'yes' ] ; then
     VERSION="$(sed -ne 's/^VERSION *= *//p' Makefile)"
     if [ "$SUFFIX" != "$VERSION" ] ; then
       mv "flexdll-bin-$VERSION.zip" "flexdll-bin-$SUFFIX.zip"
+      mv "flexlink-bin-$VERSION.zip" "flexlink-bin-$SUFFIX.zip"
       mv "flexdll-$VERSION-setup.exe" "flexdll-$SUFFIX-setup.exe"
     fi
     appveyor PushArtifact "flexdll-$SUFFIX-setup.exe"
     appveyor PushArtifact "flexdll-bin-$SUFFIX.zip"
+    appveyor PushArtifact "flexlink-bin-$SUFFIX.zip"
 
     popd &> /dev/null
 fi

--- a/flexdll-bin.install
+++ b/flexdll-bin.install
@@ -1,0 +1,20 @@
+libexec: [
+  "flexlink.exe"
+]
+lib: [
+  "default.manifest"
+  "default_amd64.manifest"
+  "flexdll.h"
+  "?flexdll_mingw.o"
+  "?flexdll_initer_mingw.o"
+  "?flexdll_mingw64.o"
+  "?flexdll_initer_mingw64.o"
+  "?flexdll_msvc.obj"
+  "?flexdll_initer_msvc.obj"
+  "?flexdll_msvc64.obj"
+  "?flexdll_initer_msvc64.obj"
+  "?flexdll_cygwin.o"
+  "?flexdll_initer_cygwin.o"
+  "?flexdll_cygwin64.o"
+  "?flexdll_initer_cygwin64.o"
+]

--- a/flexdll-bin.opam
+++ b/flexdll-bin.opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+version: "0.42"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Binary Release"
+description: "Precompiled flexlink.exe binary (built using 32-bit mingw-w64)
+required for building OCaml 3.11.0-4.02.3"
+build: [
+  ["./flexlink.exe" "-vnum"] {dev}
+  [make "MSVC_DETECT=0" "support"
+        "CHAINS=mingw" {ocaml-option-32bit:installed & ocaml-option-mingw:installed}
+        "CHAINS=mingw64" {!ocaml-option-32bit:installed & ocaml-option-mingw:installed}
+        "CHAINS=msvc" {ocaml-option-32bit:installed & ocaml-option-msvc:installed}
+        "CHAINS=msvc64" {!ocaml-option-32bit:installed & ocaml-option-msvc:installed}
+        "CHAINS=cygwin" {ocaml-option-32bit:installed & !ocaml-option-mingw:installed & !ocaml-option-msvc:installed}
+        "CHAINS=cygwin64" {!ocaml-option-32bit:installed & !ocaml-option-mingw:installed & !ocaml-option-msvc:installed}]
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-mingw"
+  "ocaml-option-msvc"
+]
+available: os = "win32" | os = "cygwin"
+flags: avoid-version
+post-messages: [
+  "This package cannot be pinned to a repository commit" {dev & failure}
+]

--- a/flexdll.install
+++ b/flexdll.install
@@ -1,0 +1,14 @@
+share: [
+  "Makefile"
+  "cmdline.ml"
+  "coff.ml"
+  "Compat.ml.in"
+  "create_dll.ml"
+  "default.manifest"
+  "default_amd64.manifest"
+  "flexdll.c"
+  "flexdll.h"
+  "flexdll_initer.c"
+  "reloc.ml"
+  "version.rc"
+]

--- a/flexdll.opam
+++ b/flexdll.opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+version: "0.42"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."

--- a/flexlink.install
+++ b/flexlink.install
@@ -1,0 +1,19 @@
+bin: [
+  "flexlink.exe"
+]
+lib_root: [
+  "default.manifest" {"ocaml/default.manifest"}
+  "default_amd64.manifest" {"ocaml/default_amd64.manifest"}
+  "?flexdll_mingw.o" {"ocaml/flexdll_mingw.o"}
+  "?flexdll_initer_mingw.o" {"ocaml/flexdll_initer_mingw.o"}
+  "?flexdll_mingw64.o" {"ocaml/flexdll_mingw64.o"}
+  "?flexdll_initer_mingw64.o" {"ocaml/flexdll_initer_mingw64.o"}
+  "?flexdll_msvc.obj" {"ocaml/flexdll_msvc.obj"}
+  "?flexdll_initer_msvc.obj" {"ocaml/flexdll_initer_msvc.obj"}
+  "?flexdll_msvc64.obj" {"ocaml/flexdll_msvc64.obj"}
+  "?flexdll_initer_msvc64.obj" {"ocaml/flexdll_initer_msvc64.obj"}
+  "?flexdll_cygwin.o" {"ocaml/flexdll_cygwin.o"}
+  "?flexdll_initer_cygwin.o" {"ocaml/flexdll_initer_cygwin.o"}
+  "?flexdll_cygwin64.o" {"ocaml/flexdll_cygwin64.o"}
+  "?flexdll_initer_cygwin64.o" {"ocaml/flexdll_initer_cygwin64.o"}
+]

--- a/flexlink.opam
+++ b/flexlink.opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+version: "0.42"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Linker"
+description: "Used after compiling OCaml with the precompiled binary release
+of FlexDLL to rebuild and install flexlink.exe using the new OCaml compiler."
+build-env: PATH += "%{lib}%/%{flexdll-bin:installed?flexdll-bin:ocaml}%"
+build: [
+  [make "MSVC_DETECT=0" "support" "flexlink.exe"
+        "CHAINS=mingw" {ocaml-option-32bit:installed & ocaml-option-mingw:installed}
+        "CHAINS=mingw64" {!ocaml-option-32bit:installed & ocaml-option-mingw:installed}
+        "CHAINS=msvc" {ocaml-option-32bit:installed & ocaml-option-msvc:installed}
+        "CHAINS=msvc64" {!ocaml-option-32bit:installed & ocaml-option-msvc:installed}
+        "CHAINS=cygwin" {ocaml-option-32bit:installed & !ocaml-option-mingw:installed & !ocaml-option-msvc:installed}
+        "CHAINS=cygwin64" {!ocaml-option-32bit:installed & !ocaml-option-mingw:installed & !ocaml-option-msvc:installed}]
+]
+depends: [
+  "ocaml"
+  "flexdll-bin" {= _:version}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-mingw"
+  "ocaml-option-msvc"
+]
+available: (opam-version >= "2.2" & os = "win32") | os = "cygwin"

--- a/version.rc
+++ b/version.rc
@@ -9,8 +9,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,0,0,42
- PRODUCTVERSION 0,0,0,42
+ FILEVERSION FLEXDLL_VERSION
+ PRODUCTVERSION FLEXDLL_VERSION
  FILEFLAGSMASK 0x3fL
  FILEFLAGS 0x0L
  FILEOS 0x40004L
@@ -21,8 +21,8 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "FileVersion", "0.0.0.42"
-            VALUE "ProductVersion", "0.0.0.42"
+            VALUE "FileVersion", FLEXDLL_VERSION_STR
+            VALUE "ProductVersion", FLEXDLL_VERSION_STR
             VALUE "ProductName", "FlexDLL"
             VALUE "FileDescription", "FlexDLL Linker"
             VALUE "LegalCopyright", "Institut National de Recherche en Informatique et en Automatique"


### PR DESCRIPTION
Final version should do this for 0.43, not for 0.42. Three packages:
- `flexdll` - installs the sources only to the switch's `share/flexdll` directory for use with `--with-flexdll` in the compiler packages
- `flexdll-bin` - uses a slightly modified binary release tarball containing the C sources and 32-bit `flexlink.exe` for use without bootstrapping in the compiler. `flexlink.exe` is installed to `lib/flexdll-bin` rather than `bin`, with the intention that the `flexlink` package then provides the correct version of `flexlink.exe` after the compiler has been built. In particular, that means that a 64-bit OCaml then has a 64-bit `flexlink` which is relevant for very large objects
- `flexlink` - intended for use _after_ `flexdll-bin`, recompiles and installs `flexlink.exe` to complete a switch.

- [ ] CI check that the version number in the pinning opam files is consistent