### PR TITLE
Support /alternatename directive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Next version
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the
   Cygwin flexdll package (David Allsopp)
+- GPR#114: Support for /alternatename directive. Fixes GPR#113 (Jonah Beckford)
 
 Version 0.42
 - GPR#106: Support -l: syntax, to allow static linking of specific libraries (David Allsopp)

--- a/reloc.ml
+++ b/reloc.ml
@@ -640,12 +640,19 @@ let patch_output filename =
    Indeed, we will create "__imp_X" (with a redirection to "X").
    Collect such cases in "imported".
 *)
-let needed imported defined unalias obj =
+let needed imported defined unalias unalternate obj =
   let rec normalize name =
     try
       let r = unalias name in
       if r <> name then normalize r else r
-    with Not_found -> name
+    with Not_found ->
+      (* Fall back to alternate name if and only if name was not found.
+         https://devblogs.microsoft.com/oldnewthing/20200731-00/?p=104024 *)
+      try
+        let r = unalternate name in
+        if r <> name then normalize r else r
+      with Not_found ->
+        name
   in
   let normalize_imp name =
     match check_prefix "__imp_" name with
@@ -707,8 +714,9 @@ let build_dll link_exe output_file files exts extra_args =
   in
   (* Collect all the available symbols, including those defined
      in default libraries *)
-  let defined, from_imports, unalias =
+  let defined, from_imports, unalias, unalternate =
     let aliases = Hashtbl.create 16 in
+    let alternates = Hashtbl.create 16 in
     let defined = ref StrSet.empty in
     let from_imports = ref StrSet.empty in (* symbols from import libraries *)
     let add_def s = defined := StrSet.add s !defined in
@@ -734,6 +742,21 @@ let build_dll link_exe output_file files exts extra_args =
         )
         (Coff.aliases obj);
 
+      (* Collect alternatenames *)
+      let collect_alternatenames alternatenames =
+        List.iter (fun s -> match String.split_on_char '=' s with
+            | [alternate_name; true_name] ->
+                debug 2 "alternatename %s -> %s" alternate_name true_name;
+                Hashtbl.add alternates alternate_name true_name
+            | _ ->
+                debug 1 "alternatenames unrecognized: %s" s;
+          ) alternatenames
+      in
+      List.iter (function
+          | ("alternatename", alternatenames) ->
+              collect_alternatenames alternatenames
+          | _ -> ())
+        (Coff.directives obj);
 
       (* Iterates through DEFAULTLIB directives *)
       let register_deflib fn =
@@ -793,7 +816,7 @@ let build_dll link_exe output_file files exts extra_args =
     if !machine = `x64 then add_def "__ImageBase"
     else add_def "___ImageBase";
 
-    !defined, !from_imports, (Hashtbl.find aliases)
+    !defined, !from_imports, (Hashtbl.find aliases), (Hashtbl.find alternates)
   in
 
   (* Determine which objects from the given libraries should be linked
@@ -830,7 +853,7 @@ let build_dll link_exe output_file files exts extra_args =
   let imported = ref StrSet.empty in
 
   let imports obj =
-    let n = needed imported defined unalias obj in
+    let n = needed imported defined unalias unalternate obj in
     imported_from_implib := StrSet.union !imported_from_implib (StrSet.inter n from_imports);
     let undefs = StrSet.diff n defined in
     StrSet.filter
@@ -910,7 +933,7 @@ let build_dll link_exe output_file files exts extra_args =
             if !explain then
               Printf.printf "%s needs %s (not found)\n%!" fn s
       )
-      (needed imported defined unalias obj)
+      (needed imported defined unalias unalternate obj)
 
   and link_libobj (libname,objname,obj) =
     if Hashtbl.mem libobjects (libname,objname) then ()


### PR DESCRIPTION
Fix for issue https://github.com/ocaml/flexdll/issues/113. Full description there.

### Testing

With 32-bit MSVC:

```powershell
Z:\source\flexdll\flexlink.exe -v -v -o src\ActorSystem\system.exe -U /out:src\ActorSystem\system.exe -implib -L "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\lib\x86" -L "C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x86" -L "C:\Program Files (x86)\Windows Kits\10\lib\10.0.19041.0\ucrt\x86" -L "C:\Program Files (x86)\Windows Kits\10\lib\10.0.19041.0\um\x86" -L "Z:\source\DkHelloWorldActor\build_community\DkSDKFiles\o\s\o\lib\ocaml" src\ActorSystem\DkHelloWorldActor_system.lib advapi32.lib ws2_32.lib version.lib -exe -no-merge-manifest -custom-crt msvcrt.lib -chain msvc -stack 16777216 -L Z:\source\DkHelloWorldActor\build_community\DkSDKFiles\o\s\o\lib\ocaml src\ActorSystem\DkHelloWorldActor_system.lib advapi32.lib ws2_32.lib version.lib libasmrund.lib src\ActorSystem\CMakeFiles\system.dir\_main.c.obj -- /nologo /pdb:src\ActorSystem\system.pdb /version:0.0 /ENTRY:wmainCRTStartup /machine:X86 /debug /INCREMENTAL /subsystem:console /MANIFEST /MANIFESTFILE:src\ActorSystem\CMakeFiles\system.dir/intermediate.manifest src\ActorSystem\CMakeFiles\system.dir/manifest.res
```

verbose logs are:

```text
** open: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\lib\x86\MSVCRTD.lib
alternatename __filter_x86_sse2_floating_point_exception -> __filter_x86_sse2_floating_point_exception_default
alias ??_Etype_info@@UAEPAXI@Z -> ??_Gtype_info@@UAEPAXI@Z
alias ??_Ebad_array_new_length@std@@UAEPAXI@Z -> ??_Gbad_array_new_length@std@@UAEPAXI@Z
alias ??_Ebad_alloc@std@@UAEPAXI@Z -> ??_Gbad_alloc@std@@UAEPAXI@Z
alias ??_Eexception@std@@UAEPAXI@Z -> ??_Gexception@std@@UAEPAXI@Z
alternatename __pRawDllMain -> __pDefaultRawDllMain
alternatename ___acrt_initialize -> ___scrt_stub_for_acrt_initialize
alternatename ___acrt_uninitialize -> ___scrt_stub_for_acrt_uninitialize
alternatename ___acrt_uninitialize_critical -> ___scrt_stub_for_acrt_uninitialize_critical
alternatename ___acrt_thread_attach -> ___scrt_stub_for_acrt_thread_attach
alternatename ___acrt_thread_detach -> ___scrt_stub_for_acrt_thread_detach
alternatename __is_c_termination_complete -> ___scrt_stub_for_is_c_termination_complete
alternatename ___vcrt_initialize -> ___scrt_stub_for_acrt_initialize
alternatename ___vcrt_uninitialize -> ___scrt_stub_for_acrt_uninitialize
alternatename ___vcrt_uninitialize_critical -> ___scrt_stub_for_acrt_uninitialize_critical
alternatename ___vcrt_thread_attach -> ___scrt_stub_for_acrt_thread_attach
alternatename ___vcrt_thread_detach -> ___scrt_stub_for_acrt_thread_detach
```

and the following bug error disappears:

```text
** Cannot resolve symbols for C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\lib\x86\msvcrt.lib(d:\agent\_work\2\s\Intermediate\vctools\msvcrt.nativeproj_110336922\objr\x86\chandler4gs.obj):
 __filter_x86_sse2_floating_point_exception
```