### PR TITLE
Coff archives: handle newline-separated long names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Next version
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the
   Cygwin flexdll package (David Allsopp)
 - GPR#114: Support for /alternatename directive. Fixes GPR#113 (Jonah Beckford)
+- GPR#117: Fix handling of object names of length > 16 in archive files. Fixes GPR#110 (Nicolás Ojeda Bär)
 
 Version 0.42
 - GPR#106: Support -l: syntax, to allow static linking of specific libraries (David Allsopp)


### PR DESCRIPTION
Static archives (`.a`) generated by GNU toolchains use newline (`\n`) as separator in the "long names" header, instead of `\000` (used in MS' toolchain). This header is used whenever object names take more than 16 bytes. The absence of `\000`'s triggered a quadratic behaviour when reading object names.

To fix this, we postprocess the "long name" string table to replace `\n` (and/or the optional trailing `/`) by `\000`. Similar logic is present in `binutils`:

https://github.com/bminor/binutils-gdb/blob/672008e6dcacddd76a5551aec9a30cd31c102d72/bfd/archive.c#L1323-L1324

(`ARFMAG[1]` is `\n` above.)

Fixes #101 