### PR TITLE
Add and fix C compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,12 @@ MSVCC64 = cl.exe $(MSVC_FLAGS)
 endif
 endif
 
+FLEXDLL_WARN_ERROR ?=
+ifeq ($(FLEXDLL_WARN_ERROR),true)
+GCC_FLAGS += -Werror -fdiagnostics-color=always
+MSVC_FLAGS += /WX
+endif
+
 show_root:
 ifeq ($(MSVCC_ROOT),)
 	@echo "$(MSVS_PATH)"

--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,16 @@ COMPAT_VERSION:=$(subst ., ,$(OCAML_VERSION))
 COMPAT_VERSION:=$(subst $(SPACE),,$(firstword $(COMPAT_VERSION))$(foreach i,$(wordlist 2,$(words $(COMPAT_VERSION)),$(COMPAT_VERSION)),$(if $(filter 0 1 2 3 4 5 6 7 8 9,$(i)),0,)$(i)))
 endif
 
+GCC_FLAGS = -Wall
+
 MINGW_PREFIX = i686-w64-mingw32-
-MINCC = $(MINGW_PREFIX)gcc
+MINCC = $(MINGW_PREFIX)gcc $(GCC_FLAGS)
 
 MINGW64_PREFIX = x86_64-w64-mingw32-
-MIN64CC = $(MINGW64_PREFIX)gcc
+MIN64CC = $(MINGW64_PREFIX)gcc $(GCC_FLAGS)
 
 CYGWIN64_PREFIX = x86_64-pc-cygwin-
-CYG64CC = $(CYGWIN64_PREFIX)gcc
+CYG64CC = $(CYGWIN64_PREFIX)gcc $(GCC_FLAGS)
 
 version.ml: Makefile flexdll.opam
 	echo "let version = \"$(VERSION)\"" > version.ml
@@ -60,7 +62,7 @@ endif
 Makefile.winsdk: msvs-detect
 	bash ./msvs-detect --output=make > $@
 
-MSVC_FLAGS=/nologo /MD -D_CRT_SECURE_NO_DEPRECATE /GS-
+MSVC_FLAGS = /nologo /MD -D_CRT_SECURE_NO_DEPRECATE /GS- /W3
 
 ifeq ($(MSVC_DETECT),0)
 # Assume that the environment is correctly set for a single Microsoft C Compiler; don't attempt to guess anything

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
     OCAML_PORT: msvc64
     ARTEFACTS: no
     FLEXDLL_VERSION: 0.43
+    FLEXDLL_WARN_ERROR: true
   matrix:
     - OCAMLBRANCH: 3.11
     - OCAMLBRANCH: 3.12

--- a/test/dump.c
+++ b/test/dump.c
@@ -20,7 +20,6 @@ void api2(char *msg){ printf("API2: %s\n", msg); }
 
 int main(int argc, char **argv)
 {
-  void *sym;
   void *handle;
   int i;
   torun *torun;


### PR DESCRIPTION
I noticed that the `CPPFLAGS` and `CFLAGS` were not being passed when building Flexdll's C files, but they introduce problems when building OCaml 4.06 and 4.07 (explanation from David Allsopp):

- The underlying OCaml compiler is msvc64, unless `OCAML_PORT` is set in AppVeyor matrix (so OCaml in the 4.06 and 4.07 tests is msvc64);
- https://github.com/ocaml/ocaml/pull/1114 (4.06.0) introduced `CFLAGS` and `CPPFLAGS` in the OCaml's installed Makefile.config;
- FlexDLL's Makefile includes that `$(ocamlopt -where)/Makefile.config` so ends up getting OCaml's msvc64 `CFLAGS` and `CPPFLAGS` values;
- https://github.com/ocaml/ocaml/pull/1840 (4.08.0) renamed them to `OC_CFLAGS` and `OC_CPPFLAGS` which removes the problem.

I've instead chosen to add `-Wall` to enable warnings when compiling C files. To make sure new problems are not introduced, the warnings are turned into errors if and only if the `CI` environment variable matches `[Tt]rue`.

I've then tentatively fixed the warnings raised by GCC and MSVC.