### PR TITLE
Fix parallel access crashes and misbehavior

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Next version
 - GPR#127: Recognise hyphens in option names in the COFF .drectve section. Fixes #126 (Reza Barazesh)
+- GPR#136: Fix parallel access crashes and misbehavior (David Allsopp, Jan Midtgaard, Antonin Décimo)
+
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/flexdll.c
+++ b/flexdll.c
@@ -501,6 +501,10 @@ void *flexdll_wdlopen(const wchar_t *file, int mode) {
 again:
   if (units_mutex == INVALID_HANDLE_VALUE) {
     HANDLE hMutex = CreateMutex(NULL, TRUE, NULL);
+    if (hMutex == NULL) {
+      if (!err->code) err->code = 1;
+      return NULL;
+    }
     if (InterlockedCompareExchangePointer(&units_mutex, hMutex, INVALID_HANDLE_VALUE) != INVALID_HANDLE_VALUE) {
       CloseHandle(hMutex);
       goto again;

--- a/flexdll.c
+++ b/flexdll.c
@@ -509,11 +509,9 @@ again:
       CloseHandle(hMutex);
       goto again;
     }
-  } else {
-    if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
+  } else if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
       if (!err->code) err->code = 1;
       return NULL;
-    }
   }
 
   handle = ll_dlopen(file, exec);

--- a/flexdll.c
+++ b/flexdll.c
@@ -582,7 +582,7 @@ void *flexdll_dlsym(void *u, const char *name) {
   void *res;
   err_t * err;
   err = get_tls_error(TLS_ERROR_NOP);
-  if(err == NULL) return NULL;
+  if (err == NULL) return NULL;
 
   if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
     if (!err->code) err->code = 1;

--- a/flexdll.c
+++ b/flexdll.c
@@ -67,7 +67,7 @@ static volatile HANDLE units_mutex = INVALID_HANDLE_VALUE;
  * - TLS_ERROR_RESET will reset what is stored in the structure, so this is
  *   intended for initialisation entry points (flexdll_dlopen, flexdll_relocate)
  * - TLS_ERROR_NOP will keep the current content of the structure, for all other
- *   entry points (flexdll_dlerror, ll_dlerror)
+ *   entry points (flexdll_dlerror, ll_dlerror, flexdll_dlsym)
  *
  * The other exported entrypoints do not need to access the error storage.
  */

--- a/flexdll.c
+++ b/flexdll.c
@@ -47,7 +47,7 @@ typedef struct dlunit {
 } dlunit;
 typedef void *resolver(void*, const char*);
 
-static volatile HANDLE what_was_I_thinking = INVALID_HANDLE_VALUE;
+static volatile HANDLE units_mutex = INVALID_HANDLE_VALUE;
 
 /* Error reporting */
 /* The latest error must be kept in some variable so that flexdll_dlerror can
@@ -499,14 +499,14 @@ void *flexdll_wdlopen(const wchar_t *file, int mode) {
 #endif /* CYGWIN */
 
 again:
-  if (what_was_I_thinking == INVALID_HANDLE_VALUE) {
+  if (units_mutex == INVALID_HANDLE_VALUE) {
     HANDLE hMutex = CreateMutex(NULL, TRUE, NULL);
-    if (InterlockedCompareExchangePointer(&what_was_I_thinking, hMutex, INVALID_HANDLE_VALUE) != INVALID_HANDLE_VALUE) {
+    if (InterlockedCompareExchangePointer(&units_mutex, hMutex, INVALID_HANDLE_VALUE) != INVALID_HANDLE_VALUE) {
       CloseHandle(hMutex);
       goto again;
     }
   } else {
-    if (WaitForSingleObject(what_was_I_thinking, INFINITE) == WAIT_FAILED) {
+    if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
       /* XXX Some kind of error here?? */
       /* error = ?? */
       return NULL;
@@ -514,7 +514,7 @@ again:
   }
 
   handle = ll_dlopen(file, exec);
-  if (!handle) { if (!err->code) err->code = 1; ReleaseMutex(what_was_I_thinking); return NULL; }
+  if (!handle) { if (!err->code) err->code = 1; ReleaseMutex(units_mutex); return NULL; }
 
   unit = units;
   while ((NULL != unit) && (unit->handle != handle)) unit = unit->next;
@@ -533,10 +533,10 @@ again:
     /* Relocation has already been done if the flexdll's DLL entry point
        is used */
     flexdll_relocate(ll_dlsym(handle, "reloctbl"));
-    if (err->code) { flexdll_dlclose(unit); ReleaseMutex(what_was_I_thinking); return NULL; }
+    if (err->code) { flexdll_dlclose(unit); ReleaseMutex(units_mutex); return NULL; }
   }
 
-  ReleaseMutex(what_was_I_thinking);
+  ReleaseMutex(units_mutex);
 
   return unit;
 }
@@ -581,14 +581,14 @@ void flexdll_dlclose(void *u) {
 
 void *flexdll_dlsym(void *u, const char *name) {
   void *res;
-  if (WaitForSingleObject(what_was_I_thinking, INFINITE) == WAIT_FAILED) {
+  if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
     /* XXX Proper error code */
     return NULL;
   }
   if (u == &main_unit) res = find_symbol_global(NULL,name);
   else if (NULL == u) res = find_symbol(&static_symtable,name);
   else res = find_symbol(((dlunit*)u)->symtbl,name);
-  ReleaseMutex(what_was_I_thinking);
+  ReleaseMutex(units_mutex);
   return res;
 }
 

--- a/flexdll.c
+++ b/flexdll.c
@@ -507,8 +507,7 @@ again:
     }
   } else {
     if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
-      /* XXX Some kind of error here?? */
-      /* error = ?? */
+      if (!err->code) err->code = 1;
       return NULL;
     }
   }
@@ -581,8 +580,12 @@ void flexdll_dlclose(void *u) {
 
 void *flexdll_dlsym(void *u, const char *name) {
   void *res;
+  err_t * err;
+  err = get_tls_error(TLS_ERROR_NOP);
+  if(err == NULL) return NULL;
+
   if (WaitForSingleObject(units_mutex, INFINITE) == WAIT_FAILED) {
-    /* XXX Proper error code */
+    if (!err->code) err->code = 1;
     return NULL;
   }
   if (u == &main_unit) res = find_symbol_global(NULL,name);

--- a/flexdll.c
+++ b/flexdll.c
@@ -47,7 +47,7 @@ typedef struct dlunit {
 } dlunit;
 typedef void *resolver(void*, const char*);
 
-static volatile HANDLE units_mutex = INVALID_HANDLE_VALUE;
+static HANDLE units_mutex = INVALID_HANDLE_VALUE;
 
 /* Error reporting */
 /* The latest error must be kept in some variable so that flexdll_dlerror can


### PR DESCRIPTION
Parallel usage is memory unsafe (read: may crash) as documented in #120, ocaml/ocaml#11607, and ocaml/ocaml#13046.

This PR goes for the simplest possible fix: adding a single global lock by dusting off the first commit of https://github.com/dra27/flexdll/tree/sledgehammer and suitable rebasing, renaming, and error handling.
Author credit thus goes to @dra27 - any errors are mine.

For the error handling, I've tried to make it fit with @shym's TLS-based error handling from #112.
I'm unsure how to test these error code paths though without explicitly mocking with the source code to create an invalid lock handle.

With the fix
- the ocaml/ocaml testsuite passes incl. the disabled `tests/lib-dynlink-domains` test from ocaml/ocaml#11607
- the reproducer from ocaml/ocaml#13046 also passes
- the `Dynlink` stress test from `multicoretests` passes

(these have been tested under MinGW in a Cygwin-shell)
