### PR TITLE
msvc, mingw: do not use cygpath by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Next version
 - GPR#127: Recognise hyphens in option names in the COFF .drectve section. Fixes #126 (Reza Barazesh)
-- GPR#140: Do not try to use `cygpath` by default with the MSVC toolschain. Fixes #139 (Nicolás Ojeda Bär)
+- GPR#140: Do not try to use `cygpath` by default with the MSVC toolchain. Fixes #139 (Nicolás Ojeda Bär)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Next version
 - GPR#127: Recognise hyphens in option names in the COFF .drectve section. Fixes #126 (Reza Barazesh)
+- GPR#140: Do not try to use `cygpath` by default with the MSVC and MINGW toolschains. Fixes #139 (Nicolás Ojeda Bär)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Next version
 - GPR#127: Recognise hyphens in option names in the COFF .drectve section. Fixes #126 (Reza Barazesh)
-- GPR#140: Do not try to use `cygpath` by default with the MSVC and MINGW toolschains. Fixes #139 (Nicolás Ojeda Bär)
+- GPR#140: Do not try to use `cygpath` by default with the MSVC toolschain. Fixes #139 (Nicolás Ojeda Bär)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/reloc.ml
+++ b/reloc.ml
@@ -1507,6 +1507,12 @@ let all_files () =
 
 let main () =
   parse_cmdline ();
+
+  begin match !toolchain with
+  | `MSVC | `MSVC64 | `MINGW | `MINGW64 when !use_cygpath = `Try -> use_cygpath := `No
+  | _ -> ()
+  end;
+
   setup_toolchain ();
 
   if !verbose >= 2 then (

--- a/reloc.ml
+++ b/reloc.ml
@@ -1509,7 +1509,7 @@ let main () =
   parse_cmdline ();
 
   begin match !toolchain with
-  | `MSVC | `MSVC64 | `MINGW | `MINGW64 when !use_cygpath = `Try -> use_cygpath := `No
+  | `MSVC | `MSVC64 when !use_cygpath = `Try -> use_cygpath := `No
   | _ -> ()
   end;
 


### PR DESCRIPTION
The default value of `use_cygpath` is `Try`, contrary to what the help string https://github.com/ocaml/flexdll/blob/a60821e4c2cec5142ac2437e7605473cc4254ea9/cmdline.ml#L150 says.

Fixes #139 