### PR TITLE
Support relocation kind 0003 and extend IMAGE_REL_ types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,8 @@
 Next version
 - GPR#127: Recognise hyphens in option names in the COFF .drectve section. Fixes #126 (Reza Barazesh)
 - GPR#136: Fix parallel access crashes and misbehavior (David Allsopp, Jan Midtgaard, Antonin Décimo)
-
+- GPR#140: Fixes #29. Support relocation kind 0003 (IMAGE_REL_AMD64_ADDR32NB) and
+  IMAGE_REL_I386_DIR32NB. Extend relative types to IMAGE_REL_AMD64_REL32_5. (Jonah Beckford)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ A very small advantage might be that there will be fewer relocations at
 runtime and that more code pages can be shared amongst several instances
 of the same DLL used by different processes.
 
-A big advantage on IA-64 systems is to avoid relocation errors like:
+A big advantage on x86_64 systems is to avoid relocation errors like:
 
 ```text
 Fatal error: cannot load shared library plug1

--- a/flexdll.c
+++ b/flexdll.c
@@ -366,7 +366,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl, err_t *err) {
         err->code = 3;
         goto restore;
       }
-      *((UINT32*) ptr->addr) = s;
+      *((UINT32*) ptr->addr) = (INT32) s;
       break;
     case RELOC_32NB:
       s += *((INT32*) ptr -> addr);
@@ -375,7 +375,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl, err_t *err) {
         err->code = 3;
         goto restore;
       }
-      *((UINT32*) ptr->addr) = s;
+      *((UINT32*) ptr->addr) = (INT32) s;
       break;
     default:
       fprintf(stderr, "flexdll: unknown relocation kind");

--- a/flexdll.c
+++ b/flexdll.c
@@ -26,11 +26,15 @@
 typedef long intnat;
 typedef unsigned long uintnat;
 
+/* RELOC_ constants except RELOC_DONE have ordinal values based on when
+   they were introduced to the code base. These ordinal values are
+   persisted in .obj files so do not re-use any existing ordinals. */
 #define RELOC_REL32     0x0001
 #define RELOC_ABS       0x0002
-#define RELOC_REL32_4   0x0003
 #define RELOC_REL32_1   0x0004
 #define RELOC_REL32_2   0x0005
+#define RELOC_REL32_3   0x0008
+#define RELOC_REL32_4   0x0003
 #define RELOC_REL32_5   0x0006
 #define RELOC_32NB      0x0007
 #define RELOC_DONE      0x0100
@@ -328,16 +332,6 @@ static void relocate(resolver f, void *data, reloctbl *tbl, err_t *err) {
       }
       *((UINT32*) ptr->addr) = (INT32) s;
       break;
-    case RELOC_REL32_4:
-      s -= (INT_PTR)(ptr -> addr) + 8;
-      s += *((INT32*) ptr -> addr);
-      if (s != (INT32) s) {
-        sprintf(err->message, "flexdll error: cannot relocate RELOC_REL32_4, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
-        err->code = 3;
-        goto restore;
-      }
-      *((UINT32*) ptr->addr) = (INT32) s;
-      break;
     case RELOC_REL32_1:
       s -= (INT_PTR)(ptr -> addr) + 5;
       s += *((INT32*) ptr -> addr);
@@ -353,6 +347,26 @@ static void relocate(resolver f, void *data, reloctbl *tbl, err_t *err) {
       s += *((INT32*) ptr -> addr);
       if (s != (INT32) s) {
         sprintf(err->message, "flexdll error: cannot relocate RELOC_REL32_2, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
+        err->code = 3;
+        goto restore;
+      }
+      *((UINT32*) ptr->addr) = (INT32) s;
+      break;
+    case RELOC_REL32_3:
+      s -= (INT_PTR)(ptr -> addr) + 7;
+      s += *((INT32*) ptr -> addr);
+      if (s != (INT32) s) {
+        sprintf(err->message, "flexdll error: cannot relocate RELOC_REL32_3, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
+        err->code = 3;
+        goto restore;
+      }
+      *((UINT32*) ptr->addr) = (INT32) s;
+      break;
+    case RELOC_REL32_4:
+      s -= (INT_PTR)(ptr -> addr) + 8;
+      s += *((INT32*) ptr -> addr);
+      if (s != (INT32) s) {
+        sprintf(err->message, "flexdll error: cannot relocate RELOC_REL32_4, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
         err->code = 3;
         goto restore;
       }

--- a/flexdll.c
+++ b/flexdll.c
@@ -31,6 +31,8 @@ typedef unsigned long uintnat;
 #define RELOC_REL32_4   0x0003
 #define RELOC_REL32_1   0x0004
 #define RELOC_REL32_2   0x0005
+#define RELOC_REL32_5   0x0006
+#define RELOC_32NB      0x0007
 #define RELOC_DONE      0x0100
 
 typedef struct { UINT_PTR kind; char *name; UINT_PTR *addr; } reloc_entry;
@@ -355,6 +357,25 @@ static void relocate(resolver f, void *data, reloctbl *tbl, err_t *err) {
         goto restore;
       }
       *((UINT32*) ptr->addr) = (INT32) s;
+      break;
+    case RELOC_REL32_5:
+      s -= (INT_PTR)(ptr -> addr) + 9;
+      s += *((INT32*) ptr -> addr);
+      if (s != (INT32) s) {
+        sprintf(err->message, "flexdll error: cannot relocate RELOC_REL32_5, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
+        err->code = 3;
+        goto restore;
+      }
+      *((UINT32*) ptr->addr) = s;
+      break;
+    case RELOC_32NB:
+      s += *((INT32*) ptr -> addr);
+      if (s != (INT32) s) {
+        sprintf(err->message, "flexdll error: cannot relocate %s RELOC_32NB, target is too far: %p  %p", ptr->name, (void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
+        err->code = 3;
+        goto restore;
+      }
+      *((UINT32*) ptr->addr) = s;
       break;
     default:
       fprintf(stderr, "flexdll: unknown relocation kind");

--- a/reloc.ml
+++ b/reloc.ml
@@ -433,6 +433,10 @@ let add_reloc_table obj obj_name p =
         | `x64, 0x01 (* IMAGE_REL_AMD64_ADDR64 *) ->
             0x0002 (* absolute, native size (32/64) *)
 
+        | `x86, 0x07 (* IMAGE_REL_I386_DIR32NB *)
+        | `x64, 0x03 (* IMAGE_REL_AMD64_ADDR32NB *) ->
+            0x0007 (* 32nb *)
+
         | `x64, 0x04 (* IMAGE_REL_AMD64_REL32 *)
         | `x86, 0x14 (* IMAGE_REL_I386_REL32 *) when not !no_rel_relocs ->
             0x0001 (* rel32 *)
@@ -440,6 +444,7 @@ let add_reloc_table obj obj_name p =
         | `x64, 0x05 when not !no_rel_relocs -> 0x0004 (* rel32_1 *)
         | `x64, 0x08 when not !no_rel_relocs-> 0x0003 (* rel32_4 *)
         | `x64, 0x06 when not !no_rel_relocs-> 0x0005 (* rel32_2 *)
+        | `x64, 0x09 when not !no_rel_relocs-> 0x0006 (* rel32_5 *)
 
         | (`x86 | `x64), (0x0a (* IMAGE_REL_{I386|AMD64}_SECTION *) |
                           0x0b (* IMAGE_REL_{I386|AMD64}_SECREL*) ) ->

--- a/reloc.ml
+++ b/reloc.ml
@@ -427,7 +427,11 @@ let add_reloc_table obj obj_name p =
   let syms = ref [] in
   let reloc secsym min max rel =
     if p rel.symbol then (
-      (* kind *)
+      (* kind = f(machine,rtype)
+         - a RELOC_ constant in flexdll.c
+
+         rtype
+         - https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#x64-processors *)
       let kind = match !machine, rel.rtype with
         | `x86, 0x06 (* IMAGE_REL_I386_DIR32 *)
         | `x64, 0x01 (* IMAGE_REL_AMD64_ADDR64 *) ->
@@ -441,10 +445,16 @@ let add_reloc_table obj obj_name p =
         | `x86, 0x14 (* IMAGE_REL_I386_REL32 *) when not !no_rel_relocs ->
             0x0001 (* rel32 *)
 
-        | `x64, 0x05 when not !no_rel_relocs -> 0x0004 (* rel32_1 *)
-        | `x64, 0x08 when not !no_rel_relocs-> 0x0003 (* rel32_4 *)
-        | `x64, 0x06 when not !no_rel_relocs-> 0x0005 (* rel32_2 *)
-        | `x64, 0x09 when not !no_rel_relocs-> 0x0006 (* rel32_5 *)
+        | `x64, 0x05 (* IMAGE_REL_AMD64_REL32_1 *) when not !no_rel_relocs->
+            0x0004 (* rel32_1 *)
+        | `x64, 0x06 (* IMAGE_REL_AMD64_REL32_2 *) when not !no_rel_relocs->
+            0x0005 (* rel32_2 *)
+        | `x64, 0x07 (* IMAGE_REL_AMD64_REL32_3 *) when not !no_rel_relocs->
+            0x0008 (* rel32_3 *)
+        | `x64, 0x08 (* IMAGE_REL_AMD64_REL32_4 *) when not !no_rel_relocs->
+            0x0003 (* rel32_4 *)
+        | `x64, 0x09 (* IMAGE_REL_AMD64_REL32_5 *) when not !no_rel_relocs->
+            0x0006 (* rel32_5 *)
 
         | (`x86 | `x64), (0x0a (* IMAGE_REL_{I386|AMD64}_SECTION *) |
                           0x0b (* IMAGE_REL_{I386|AMD64}_SECREL*) ) ->


### PR DESCRIPTION
Fixes #29 . 

Specifically adds support for:

- IMAGE_REL_AMD64_ADDR32NB. (This is the "relocation kind 0003").

- IMAGE_REL_I386_DIR32NB. (This is the x86 version of the above).

- IMAGE_REL_AMD64_REL32_5. (This is documented but weirdly not implemented).

Tested with my ucrt branch https://github.com/jonahbeckford/flexdll/tree/0.43%2Bucrt where relocation kind 0003 occurs often. It especially occurs in "normal" C libraries (ucvrt; `/MD`) that are linked into an OCaml executable. None of the tested code used `/GS-`.

References:
- https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-relocations-object-only
- https://github.com/llvm/llvm-project/blob/279953f1da7d7d0e404638414deec5d1df291c7c/lld/COFF/Chunks.cpp#L113-L158