### PR TITLE
Make `-lgcc_eh` on mingw-w64 optional

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Next version
 - GPR#156: Allow choosing an alternative linker and manifest tool at runtime
   with -use-linker=<cmd> and -use-mt=<cmd>.
   (Antonin Décimo, review by David Allsopp)
+- GPR#133, GPR#147: Allow default libraries to be marked as optional (David Allsopp, report by Romain Beauxis)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the


### PR DESCRIPTION
Should fix #133. As noted in ocaml/ocaml#12996, there are configurations where `-lgcc_eh` isn't available (and therefore required). The change is simply to resolve `-lgcc_eh` and only add it to `default_libs` if it's actually found - although it's a slightly noisier change than that simplicity implies!