### PR TITLE
Pass -pthread to the linker

### DIFF
--- a/cmdline.ml
+++ b/cmdline.ml
@@ -89,8 +89,8 @@ let specs = [
   "-base", Arg.String (fun s -> base_addr := s),
   " Specify base address (Win64 only)";
 
-  "-pthread", Arg.Unit (fun () -> ()),
-  "Ignored";
+  "-pthread", Arg.Unit (fun () -> extra_args := "-pthread" :: !extra_args),
+  " Pass -pthread to the linker";
 
   "-I", Arg.String (fun dir -> dirs := dir :: !dirs),
   "<dir> Add a directory where to search for files";

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -89,6 +89,9 @@ let specs = [
   "-base", Arg.String (fun s -> base_addr := s),
   " Specify base address (Win64 only)";
 
+  "-pthread", Arg.Unit (fun () -> ()),
+  "Ignored";
+
   "-I", Arg.String (fun dir -> dirs := dir :: !dirs),
   "<dir> Add a directory where to search for files";
 


### PR DESCRIPTION
The `-pthread` option keeps surfacing through the different compilation configurations I see when cross-compiling.

This PR makes it so the option is accepted and passed down to the linker.