### PR TITLE
Fix stack reserve to read from the COFF file header

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ Next version
 - GPR#136: Fix parallel access crashes and misbehavior (David Allsopp, Jan Midtgaard, Antonin Décimo)
 - GPR#140: Fixes #29. Support relocation kind 0003 (IMAGE_REL_AMD64_ADDR32NB) and
   IMAGE_REL_I386_DIR32NB. Extend relative types to IMAGE_REL_AMD64_REL32_5. (Jonah Beckford)
+- GPR#150: Fix stack reserve incorrectly reading from the start of the PE
+  executable instead of the COFF file header. Fix reading the file address of
+  new exe header.
+  (Antonin Décimo, review by David Allsopp and Nicolás Ojeda Bär)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the


### PR DESCRIPTION
An invocation of flexlink (with some debug patches added) would raise:

```console
> flexlink -exe -chain msvc64 -merge-manifest -stack 33554432 -link /ENTRY:wmainCRTStartup  -o runtime/ocamlrun.exe runtime/prims.obj runtime/libcamlrun.lib ws2_32.lib ole32.lib uuid.lib advapi32.lib shell32.lib version.lib shlwapi.lib synchronization.lib
Raised by primitive operation at Coff.int16 in file "coff.ml", line 242, characters 30-49
Called from Coff.Stacksize.set_stack_reserve in file "coff.ml", line 1055, characters 12-26
Called from Reloc.patch_output in file "reloc.ml", line 654, characters 16-54
Cannot set stack reserve: Invalid_argument("index out of bounds")
```

After investigating, I've found out that flexlink incorrectly reads the PE executable. The [COFF File Header (Object and Image)][1] starts just after the signature `"PE\0\0"`. The `read ic 0 20` seeks the offset 0 (the start) in the PE file, instead of the offset of the header. This leads to incorrectly reading ~and writing~ values in the PE headers.

[1]: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#coff-file-header-object-and-image

The first patch fixes the problem, the second renames the variables to follow the documentation more closely.