### PR TITLE
Use response files with all the toolchains

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Next version
   (respectively) MINCC_PREFIX, MIN64CC_PREFIX, CYG64_PREFIX.
   Fix FlexDLL cross-build on macOS and BSD.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
+- GPR#151: Use response files with all toolchains (Puneeth Chaganti, review by David Allsopp and Antonin Décimo)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the


### PR DESCRIPTION
Response files were added to gcc 4.2.0 [1], but Cygwin was stuck on gcc
3.4.4 for ages until mingw-w64 was introduced at gcc 4.5 (Cygwin's gcc
itself still lagged for a while) cf. [2]. (Based on inputs from @dra27).

So, in 2008 [3], it was correct to avoid using response files with
CYGWIN & MINGW. Later, support was added for the GNAT toolchain based on
the MINGW toolchain, also avoiding the use of response files. But, now
all the platforms could benefit from using response files. This commit
enables the use of response files for all toolchains, including GNAT
since the GNAT compiler is based on gcc [4].

The UTF-16 conversion of paths seems to have been primarily implemented
for MSVC[5] and causes issues with MINGW64. The linker fails with a
"file not found" error with a weird 2 character file path, which seems
like an encoding issue when reading the Byte Order Mark written during
the conversion. This commit turns off the UTF-16 conversion when not
using the MSVC or LIGHTLD toolchains.

[1] - https://github.com/gcc-mirror/gcc/commit/9d5305381ff11ba5615705672115079ffb7b0750
[2] - http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/2010/09/14/020013/index.html
[3] -
https://github.com/ocaml/flexdll/commit/fb849384d6c73232c588cae0535bed63a3330798
[4] - https://github.com/ocaml/flexdll/pull/151#issuecomment-2613980304
[5] - https://github.com/ocaml/flexdll/issues/36
