### PR TITLE
Use a file to pass arguments to cygpath

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Next version
   Fix FlexDLL cross-build on macOS and BSD.
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 - GPR#151: Use response files with all toolchains (Puneeth Chaganti, review by David Allsopp and Antonin Décimo)
+- GPR#152: Use a file to pass arguments to cygpath (Puneeth Chaganti, review by David Allsopp and Antonin Décimo)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/Compat.ml.in
+++ b/Compat.ml.in
@@ -136,6 +136,7 @@
 401:  include Sys
 401:
 401:  let win32 = (Sys.os_type = "Win32")
+401:  let cygwin = (Sys.os_type = "Cygwin")
 401:end
 
 402:type bytes = string


### PR DESCRIPTION
When linking a fairly large OCaml project in Windows, I run into an 'argument list too long' error when trying to resolve filenames in `build_dll`. This commit switches to using a file to pass a long arguments list to cygpath, similar to our use of response files.

See also #151 