### PR TITLE
Build in C99 mode in CI with cc-like compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ endif
 
 FLEXDLL_WARN_ERROR ?=
 ifeq ($(FLEXDLL_WARN_ERROR),true)
-GCC_FLAGS += -Werror -fdiagnostics-color=always
+GCC_FLAGS += -Wextra -std=c99 -Werror -fdiagnostics-color=always
 MSVC_FLAGS += /WX
 endif
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,10 @@ environment:
       OCAML_PORT: mingw64
     - OCAMLBRANCH: 5.1
       OCAML_PORT: mingw64
+    - OCAMLBRANCH: 5.2
+      OCAML_PORT: mingw64
+    - OCAMLBRANCH: 5.3
+      OCAML_PORT: mingw64
       SKIP_OCAML_TEST: no
     - OCAMLBRANCH: trunk
       OCAML_PORT: mingw64

--- a/flexdll.c
+++ b/flexdll.c
@@ -9,6 +9,10 @@
 
 /* Runtime support library */
 
+#ifdef CYGWIN
+#define _POSIX_C_SOURCE 200112L
+#include <stdlib.h> /* for setenv */
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <windows.h>
@@ -157,6 +161,7 @@ static err_t *get_tls_error(int op) {
 #include <dlfcn.h>
 
 static void *ll_dlopen(const char *libname, int for_execution) {
+  (void)for_execution; /* for_execution is currently unused */
   return dlopen(libname, RTLD_NOW | RTLD_GLOBAL);
   /* Could use RTLD_LAZY if for_execution == 0, but needs testing */
 }
@@ -228,7 +233,7 @@ static void dump_reloctbl(reloctbl *tbl) {
   nonwr *wr;
 
   if (!tbl) { printf("No relocation table\n"); return; }
-  printf("Dynamic relocation table found at %p\n", tbl);
+  printf("Dynamic relocation table found at %p\n", (void *) tbl);
 
   for (wr = tbl->nonwr; wr->last != 0; wr++)
     printf(" Non-writable relocation in zone %p -> %p\n",
@@ -418,7 +423,7 @@ static void dump_symtbl(symtbl *tbl)
   unsigned i;
 
   if (!tbl) { printf("No symbol table\n"); return; }
-  printf("Dynamic symbol at %p (size = %u)\n", tbl, (unsigned int) tbl->size); fflush(stdout);
+  printf("Dynamic symbol at %p (size = %u)\n", (void *) tbl, (unsigned int) tbl->size); fflush(stdout);
 
   for (i = 0; i < tbl->size; i++) {
     printf("[%u] ", i); fflush(stdout);

--- a/flexdll_initer.c
+++ b/flexdll_initer.c
@@ -18,15 +18,13 @@
 #include <stdio.h>
 #include <windows.h>
 
-typedef int func(void*);
-
 extern int reloctbl;
 
-static int flexdll_init() {
-  func *sym = 0;
+static int flexdll_init(void) {
+  int (*sym)(void *) = 0;
   char *s = getenv("FLEXDLL_RELOCATE");
   if (!s) { fprintf(stderr, "Cannot find FLEXDLL_RELOCATE\n"); return FALSE; }
-  sscanf(s,"%p",&sym);
+  sscanf(s,"%p",(void **) &sym);
   /* sym = 0 means "loaded not for execution" */
   if (!sym || sym(&reloctbl)) return TRUE;
   return FALSE;

--- a/test/dump.c
+++ b/test/dump.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include "flexdll.h"
 
-typedef void torun();
+typedef void torun(void);
 
 void api1(char *msg){ printf("API1: %s\n", msg); }
 void api2(char *msg){ printf("API2: %s\n", msg); }

--- a/test/plug1.c
+++ b/test/plug1.c
@@ -3,5 +3,5 @@
 #include "api.h"
 
 int x = 10;
-void dump_x() { printf("AAA\nx=%i\n", x); }
-void torun() { api1("plug1.torun();"); api2("plug1.torun();"); }
+void dump_x(void) { printf("AAA\nx=%i\n", x); }
+void torun(void) { api1("plug1.torun();"); api2("plug1.torun();"); }

--- a/test/plug2.c
+++ b/test/plug2.c
@@ -2,7 +2,7 @@
 
 extern int x;
 
-void torun() {
+void torun(void) {
   api1("plug2.torun();");
   api2("plug2.torun();");
   /*


### PR DESCRIPTION
This is done to ensure FlexDLL can be built with old compilers or strict compiler settings.

It's not possible to use the `-Wpedantic` flag because we're casting function pointers into object pointers, or to use a strict C89 mode as we're using flexible array members (a C99 feature).

(the current little CI failure is a network problem)