### PR TITLE
Allow choosing an alternative linker and manifest tool at runtime

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,9 @@ Next version
   (Antonin Décimo, review by Nicolás Ojeda Bär)
 - GPR#151: Use response files with all toolchains (Puneeth Chaganti, review by David Allsopp and Antonin Décimo)
 - GPR#152: Use a file to pass arguments to cygpath (Puneeth Chaganti, review by David Allsopp and Antonin Décimo)
+- GPR#156: Allow choosing an alternative linker and manifest tool at runtime
+  with -use-linker=<cmd> and -use-mt=<cmd>.
+  (Antonin Décimo, review by David Allsopp)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/Compat.ml.in
+++ b/Compat.ml.in
@@ -101,6 +101,7 @@
 408:module Option = struct
 408:  let some v = Some v
 408:  let value o ~default = match o with Some v -> v | None -> default
+408:  let fold ~none ~some = function Some v -> some v | None -> none
 408:end
 
 407:module Stdlib = Pervasives

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -21,6 +21,7 @@ let subsystem = ref "console"
 let explain = ref false
 let builtin_linker = ref false
 let toolchain : [ `MSVC | `MSVC64 | `MINGW | `MINGW64 | `GNAT | `GNAT64 | `CYGWIN64 | `LIGHTLD ] ref = ref `MSVC
+let use_linker = ref None
 let save_temps = ref false
 let show_exports = ref false
 let show_imports = ref false
@@ -115,6 +116,9 @@ let specs = [
                           | "ld" -> `LIGHTLD
 			  | _ -> assert false)),
   " Choose which linker to use";
+
+  "-use-linker", Arg.String (fun s -> use_linker := Some s),
+  "<cmd> Choose an alternative linker to use";
 
   "-x64", Arg.Unit (fun () -> machine := `x64; underscore := false; toolchain := `MSVC64),
   " (Deprecated)";

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -22,6 +22,7 @@ let explain = ref false
 let builtin_linker = ref false
 let toolchain : [ `MSVC | `MSVC64 | `MINGW | `MINGW64 | `GNAT | `GNAT64 | `CYGWIN64 | `LIGHTLD ] ref = ref `MSVC
 let use_linker = ref None
+let use_mt = ref None
 let save_temps = ref false
 let show_exports = ref false
 let show_imports = ref false
@@ -119,6 +120,9 @@ let specs = [
 
   "-use-linker", Arg.String (fun s -> use_linker := Some s),
   "<cmd> Choose an alternative linker to use";
+
+  "-use-mt", Arg.String (fun s -> use_mt := Some s),
+  "<cmd> Choose an alternative manifest tool to use";
 
   "-x64", Arg.Unit (fun () -> machine := `x64; underscore := false; toolchain := `MSVC64),
   " (Deprecated)";

--- a/reloc.ml
+++ b/reloc.ml
@@ -1237,7 +1237,9 @@ let build_dll link_exe output_file files exts extra_args =
           Filename.concat flexdir default_manifest
       in
       let mcmd =
-        Printf.sprintf "mt -nologo -outputresource:%s -manifest %s"
+        let mt = Option.value !Cmdline.use_mt ~default:"mt" in
+        Printf.sprintf "%s -nologo -outputresource:%s -manifest %s"
+          mt
           (Filename.quote (if link_exe = `EXE then output_file
                            else output_file ^ ";#2"))
           (Filename.quote fn)


### PR DESCRIPTION
Introduce two new options, `-use-linker=<cmd>` and `-use-mt=<cmd>`.

This allows using `lld-link` instead of `link`, for instance; and allows using `llvm-mt` instead of `mt.exe`.

The options accept any string blindly, but we could restrict to `bfd`, `gold`, `lld`, `mold`, `link`, and `lld-link` (if so, users may have to provide symlinks if the linker is versioned, e.g. make `lld-link` point to `lld-link-20`).

