### PR TITLE
Improve flexlink support on Unix (for cross-compiling contexts)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Next version
   with -use-linker=<cmd> and -use-mt=<cmd>.
   (Antonin Décimo, review by David Allsopp)
 - GPR#133, GPR#147: Allow default libraries to be marked as optional (David Allsopp, report by Romain Beauxis)
+- GPR#157: Improve flexlink support on Unix (for cross-compiling contexts).
+  (Antonin Décimo, review by David Allsopp)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/Compat.ml.in
+++ b/Compat.ml.in
@@ -138,6 +138,7 @@
 401:
 401:  let win32 = (Sys.os_type = "Win32")
 401:  let cygwin = (Sys.os_type = "Cygwin")
+401:  let unix = (Sys.os_type = "Unix")
 401:end
 
 402:type bytes = string

--- a/reloc.ml
+++ b/reloc.ml
@@ -204,7 +204,7 @@ let run_command cmd =
   in
   (* note: for Cygwin, using bash allow to follow symlinks to find
      gcc... *)
-  if !toolchain = `CYGWIN64 ||
+  if Sys.unix || !toolchain = `CYGWIN64 ||
      String.length cmd + String.length silencer > max_command_length
   then begin
     (* Dump the command in a text file and apply bash to it. *)
@@ -1128,7 +1128,9 @@ let build_dll link_exe output_file files exts extra_args =
         let extra_args =
           (* FlexDLL doesn't process .voltbl sections correctly, so don't allow the linker
              to process them. *)
-          let command = link ^ " | findstr EMITVOLATILEMETADATA > NUL" in
+          let command =
+            if Sys.win32 then link ^ " /nologo /? | findstr EMITVOLATILEMETADATA > NUL"
+            else link ^ " /nologo '/?' | grep -iq emitvolatilemetadata >/dev/null" in
           if Sys.command command = 0 then
             "/EMITVOLATILEMETADATA:NO " ^ extra_args
           else extra_args

--- a/reloc.ml
+++ b/reloc.ml
@@ -235,7 +235,7 @@ let quote_files lst =
   let s =
     String.concat " "
       (List.map (fun f -> if f = "" then f else Filename.quote f) lst) in
-  if String.length s >= 1024 then Filename.quote (build_diversion lst)
+  if not Sys.unix && String.length s >= 1024 then Filename.quote (build_diversion lst)
   else s
 
 


### PR DESCRIPTION
When flexlink runs on Unix in cross-compiling contexts, it shouldn't use `cmd.exe` or batch syntax, or response files.