### PR TITLE
Improve support of clang

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,10 @@ Next version
 - GPR#133, GPR#147: Allow default libraries to be marked as optional (David Allsopp, report by Romain Beauxis)
 - GPR#157: Improve flexlink support on Unix (for cross-compiling contexts).
   (Antonin Décimo, review by David Allsopp)
+- GPR#158: Reuse the compilers used during the build for later operations, such
+  as querying the compilers for their library search paths. Support parsing
+  clang output.
+  (Antonin Décimo, review by David Allsopp)
 
 Version 0.43
 - GPR#108: Add -lgcc_s to Cygwin's link libraries, upstreaming a patch from the

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,15 @@ CYGWIN64_PREFIX = x86_64-pc-cygwin-
 CYG64CC = $(CYGWIN64_PREFIX)gcc
 
 version.ml: Makefile flexdll.opam
-	echo "let version = \"$(VERSION)\"" > version.ml
-	echo "let mingw_prefix = \"$(MINGW_PREFIX)\"" >> version.ml
-	echo "let mingw64_prefix = \"$(MINGW64_PREFIX)\"" >> version.ml
+	echo 'let version = "$(VERSION)"' > $@
+	echo 'let mingw_prefix = "$(MINGW_PREFIX)"' >> $@
+	echo 'let mingw64_prefix = "$(MINGW64_PREFIX)"' >> $@
+	echo 'let msvc = "$(notdir $(MSVCC))"' >> $@
+	echo 'let msvc64 = "$(notdir $(MSVCC64))"' >> $@
+	echo 'let cygwin64 = "$(notdir $(CYG64CC))"' >> $@
+	echo 'let mingw = "$(notdir $(MINCC))"' >> $@
+	echo 'let mingw64 = "$(notdir $(MIN64CC))"' >> $@
+	echo 'let gnat = "gcc"' >> $@
 
 # Supported tool-chains
 


### PR DESCRIPTION
I'm trying to use clang everywhere. The MSYS2 CLANG64 environment uses UCRT, but we're missing bits to link with it right now. It is however possible to use clang with MSYS2 MINGW64 environment, or with Cygwin+mingw, or with the MSYS2 MSYS and Cygwin+cygwin1.dll environments (although in this last two cases clang packages are currently unmaintained).
It is also possible to use clang-cl instead of MSVC.

This PR makes sure that flexlink doesn't default to GCC or MSVC when clang is desired instead.

The first step is to retain the compilers used when building for searching library directories. This allows using alternative compilers, otherwise, FlexDLL would default to querying GCC, which may report different path list than clang.
The second step teaches FlexDLL to parse clang's output. `clang.exe -print-search-dirs` doesn't print an `install` field and its `libraries` path list is already in mixed-style (Windows path with forward slashes separated by semicolons). This happens when using clang in both MSYS2 MINGW64 or CLANG64 environments.