### PR TITLE
Support -mwindows and -mconsole for greater compatibility with pkg-config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Next version
+- GPR#164: Recognize `-mwindows` and `-mconsole` for greater compatibility (with
+  `pkg-config` in particular).
+  (Nicolás Ojeda Bär, review by David Allsopp)
+
 Version 0.44
 - GPR#127: Recognise hyphens in option names in the COFF .drectve section.
   Fixes #126 (Reza Barazesh)

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -203,8 +203,11 @@ let specs = [
   "-subsystem", Arg.Set_string subsystem,
   "<id> Set the subsystem (default: console)";
 
-  "-m", Arg.Set_string subsystem,
-  "<id> Set the subsystem (alias for -subsystem)";
+  "-mwindows", Arg.Unit (fun () -> subsystem := "windows"),
+  " Alias for -subsystem windows";
+
+  "-mconsole", Arg.Unit (fun () -> subsystem := "console"),
+  " Alias for -subsystem console";
 
   "-custom-crt", Arg.Set custom_crt,
   " Use a custom CRT";
@@ -263,7 +266,7 @@ let flexlinkflags =
 let parse_cmdline () =
   (* Split -lXXX, -LXXX and -IXXX options *)
   let tosplit = function
-    | "-l" | "-L" | "-I" | "-D" | "-U" | "-m" -> true
+    | "-l" | "-L" | "-I" | "-D" | "-U" -> true
     | _ -> false
   in
 

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -203,6 +203,9 @@ let specs = [
   "-subsystem", Arg.Set_string subsystem,
   "<id> Set the subsystem (default: console)";
 
+  "-m", Arg.Set_string subsystem,
+  "<id> Set the subsystem (alias for -subsystem)";
+
   "-custom-crt", Arg.Set custom_crt,
   " Use a custom CRT";
 
@@ -260,7 +263,7 @@ let flexlinkflags =
 let parse_cmdline () =
   (* Split -lXXX, -LXXX and -IXXX options *)
   let tosplit = function
-    | "-l" | "-L" | "-I" | "-D" | "-U" -> true
+    | "-l" | "-L" | "-I" | "-D" | "-U" | "-m" -> true
     | _ -> false
   in
 


### PR DESCRIPTION
Attempt in the direction of https://github.com/ocaml/flexdll/issues/163#issuecomment-3721857131.

Fixes #163