### PR TITLE
AppVeyor updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,8 +252,10 @@ demo_msvc: flexlink.exe flexdll_msvc.obj flexdll_initer_msvc.obj
 demo_cygwin64: flexlink.exe flexdll_cygwin64.o flexdll_initer_cygwin64.o
 	$(MAKE) -C test clean demo CHAIN=cygwin64 CC="$(CYG64CC)" CFLAGS="$(GCC_FLAGS)" O=o RUN="PATH=\"/cygdrive/c/cygwin64/bin:$(PATH)\""
 
+# cf. ocaml/ocaml#10046
+MINGW_DEMO_CFLAGS=-static-libgcc
 demo_mingw: flexlink.exe flexdll_mingw.o flexdll_initer_mingw.o
-	$(MAKE) -C test clean demo CHAIN=mingw CC="$(MINCC)" CFLAGS="$(GCC_FLAGS)" O=o
+	$(MAKE) -C test clean demo CHAIN=mingw CC="$(MINCC)" CFLAGS="$(GCC_FLAGS)" O=o LDFLAGS="-static-libgcc"
 
 demo_mingw64: flexlink.exe flexdll_mingw64.o flexdll_initer_mingw64.o
 	$(MAKE) -C test clean demo CHAIN=mingw64 CC="$(MIN64CC)" CFLAGS="$(GCC_FLAGS)" O=o

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,12 +86,12 @@ install:
   # Make sure the Cygwin path comes before the Git one (otherwise
   # cygpath behaves crazily), but after the MSVC one.
   - set Path=C:\cygwin64\bin;%OCAMLROOT%\bin;C:\flexdll;%Path%
-  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin make mingw64-i686-gcc-core mingw64-i686-runtime mingw64-x86_64-gcc-core mingw64-x86_64-runtime"'
   - if exist "%CYG_ROOT%\setup-x86_64.exe" del "%CYG_ROOT%\setup-x86_64.exe"
   - appveyor DownloadFile "https://cygwin.com/setup-x86_64.exe" -FileName "%CYG_ROOT%\setup-x86_64.exe"
   - '"%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages unzip,zip > nul'
   - '%CYG_ROOT%\bin\bash -lc "zip --version" > nul || "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul'
-  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin make mingw64-i686-gcc-core mingw64-i686-runtime mingw64-x86_64-gcc-core mingw64-x86_64-runtime"'
   - call "%VCVARS64%"
   - appveyor DownloadFile "https://github.com/ocaml/flexdll/archive/%FLEXDLL_VERSION%.tar.gz" -FileName "flexdll.tar.gz"
   - appveyor DownloadFile "https://github.com/ocaml/flexdll/releases/download/%FLEXDLL_VERSION%/flexdll-bin-%FLEXDLL_VERSION%.zip" -FileName "flexdll.zip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,41 +13,64 @@ environment:
     FLEXDLL_VERSION: 0.43
     FLEXDLL_WARN_ERROR: true
   matrix:
-    - OCAMLBRANCH: 3.11
-    - OCAMLBRANCH: 3.12
+    - job_name: OCaml 3.11 branch
+      OCAMLBRANCH: 3.11
+    - job_name: OCaml 3.12.1
+      OCAMLBRANCH: 3.12
       OCAMLREV: 1
-    - OCAMLBRANCH: 4.00
-    - OCAMLBRANCH: 4.01
-    - OCAMLBRANCH: 4.02
-    - OCAMLBRANCH: 4.03
+    - job_name: OCaml 4.00 branch
+      OCAMLBRANCH: 4.00
+    - job_name: OCaml 4.01 branch
+      OCAMLBRANCH: 4.01
+    - job_name: OCaml 4.02 branch
+      OCAMLBRANCH: 4.02
+    - job_name: OCaml 4.03 branch (including bootstrap)
+      OCAMLBRANCH: 4.03
       SKIP_OCAML_TEST: no
-    - OCAMLBRANCH: 4.04
-    - OCAMLBRANCH: 4.05
-    - OCAMLBRANCH: 4.06
-    - OCAMLBRANCH: 4.07
-    - OCAMLBRANCH: 4.08
-    - OCAMLBRANCH: 4.09
-    - OCAMLBRANCH: 4.10
-    - OCAMLBRANCH: 4.11
-    - OCAMLBRANCH: 4.12
+    - job_name: OCaml 4.04 branch
+      OCAMLBRANCH: 4.04
+    - job_name: OCaml 4.05 branch
+      OCAMLBRANCH: 4.05
+    - job_name: OCaml 4.06 branch
+      OCAMLBRANCH: 4.06
+    - job_name: OCaml 4.07 branch
+      OCAMLBRANCH: 4.07
+    - job_name: OCaml 4.08 branch
+      OCAMLBRANCH: 4.08
+    - job_name: OCaml 4.09 branch
+      OCAMLBRANCH: 4.09
+    - job_name: OCaml 4.10 branch
+      OCAMLBRANCH: 4.10
+    - job_name: OCaml 4.11 branch
+      OCAMLBRANCH: 4.11
+    - job_name: OCaml 4.12 branch (Win 7 SDK; mingw-w64 i686) + release artefacts
+      OCAMLBRANCH: 4.12
       OCAML_PORT: mingw
       ARTEFACTS: yes
       MSVS_PREFERENCE: SDK7.0
-    - OCAMLBRANCH: 4.13
-    - OCAMLBRANCH: 4.14
+    - job_name: OCaml 4.13 branch
+      OCAMLBRANCH: 4.13
+    - job_name: OCaml 4.14 branch (including bootstrap)
+      OCAMLBRANCH: 4.14
       SKIP_OCAML_TEST: no
-    - OCAMLBRANCH: 5.0
+    - job_name: OCaml 5.0 branch (mingw-w64 x86_64)
+      OCAMLBRANCH: 5.0
       OCAML_PORT: mingw64
-    - OCAMLBRANCH: 5.1
+    - job_name: OCaml 5.1 branch (mingw-w64 x86_64)
+      OCAMLBRANCH: 5.1
       OCAML_PORT: mingw64
-    - OCAMLBRANCH: 5.2
+    - job_name: OCaml 5.2 branch (mingw-w64 x86_64)
+      OCAMLBRANCH: 5.2
       OCAML_PORT: mingw64
-    - appveyor_build_worker_image: Visual Studio 2022
+    - job_name: OCaml 5.3 branch
+      appveyor_build_worker_image: Visual Studio 2022
       OCAMLBRANCH: 5.3
-    - appveyor_build_worker_image: Visual Studio 2022
+    - job_name: OCaml 5.4 branch (including bootstrap)
+      appveyor_build_worker_image: Visual Studio 2022
       OCAMLBRANCH: 5.4
       SKIP_OCAML_TEST: no
-    - appveyor_build_worker_image: Visual Studio 2022
+    - job_name: OCaml trunk branch (including bootstrap; mingw-w64 x86_64)
+      appveyor_build_worker_image: Visual Studio 2022
       OCAMLBRANCH: trunk
       OCAML_PORT: mingw64
       SKIP_OCAML_TEST: no

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,8 @@ environment:
       OCAML_PORT: mingw64
     - OCAMLBRANCH: 5.3
       OCAML_PORT: mingw64
+    - appveyor_build_worker_image: Visual Studio 2022
+      OCAMLBRANCH: 5.4
       SKIP_OCAML_TEST: no
     - OCAMLBRANCH: trunk
       OCAML_PORT: mingw64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     CYG_CACHE: C:/cygwin64/var/cache/setup
     OCAML_PORT: msvc64
     ARTEFACTS: no
-    FLEXDLL_VERSION: 0.43
+    FLEXDLL_VERSION: 0.44
     FLEXDLL_WARN_ERROR: true
   matrix:
     - job_name: OCaml 3.11 branch

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
     ARTEFACTS: no
     FLEXDLL_VERSION: 0.44
     FLEXDLL_WARN_ERROR: true
+    VCVARS64: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat
   matrix:
     - job_name: OCaml 3.11 branch
       OCAMLBRANCH: 3.11
@@ -64,9 +65,11 @@ environment:
       OCAML_PORT: mingw64
     - job_name: OCaml 5.3 branch
       appveyor_build_worker_image: Visual Studio 2022
+      VCVARS64: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat
       OCAMLBRANCH: 5.3
     - job_name: OCaml 5.4 branch (including bootstrap)
       appveyor_build_worker_image: Visual Studio 2022
+      VCVARS64: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat
       OCAMLBRANCH: 5.4
       SKIP_OCAML_TEST: no
     - job_name: OCaml trunk branch (including bootstrap; mingw-w64 x86_64)
@@ -89,7 +92,7 @@ install:
   - '"%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages unzip,zip > nul'
   - '%CYG_ROOT%\bin\bash -lc "zip --version" > nul || "%CYG_ROOT%\setup-x86_64.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul'
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+  - call "%VCVARS64%"
   - appveyor DownloadFile "https://github.com/ocaml/flexdll/archive/%FLEXDLL_VERSION%.tar.gz" -FileName "flexdll.tar.gz"
   - appveyor DownloadFile "https://github.com/ocaml/flexdll/releases/download/%FLEXDLL_VERSION%/flexdll-bin-%FLEXDLL_VERSION%.zip" -FileName "flexdll.zip"
   - appveyor DownloadFile "https://raw.githubusercontent.com/ocaml/ocaml/trunk/tools/msvs-promote-path" -FileName "msvs-promote-path"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,8 @@ environment:
     - appveyor_build_worker_image: Visual Studio 2022
       OCAMLBRANCH: 5.4
       SKIP_OCAML_TEST: no
-    - OCAMLBRANCH: trunk
+    - appveyor_build_worker_image: Visual Studio 2022
+      OCAMLBRANCH: trunk
       OCAML_PORT: mingw64
       SKIP_OCAML_TEST: no
   OCAMLROOT: C:/OCaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,8 +42,8 @@ environment:
       OCAML_PORT: mingw64
     - OCAMLBRANCH: 5.2
       OCAML_PORT: mingw64
-    - OCAMLBRANCH: 5.3
-      OCAML_PORT: mingw64
+    - appveyor_build_worker_image: Visual Studio 2022
+      OCAMLBRANCH: 5.3
     - appveyor_build_worker_image: Visual Studio 2022
       OCAMLBRANCH: 5.4
       SKIP_OCAML_TEST: no

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -47,6 +47,8 @@ function configure_ocaml {
     fi
 }
 
+git config --global --add safe.directory '*'
+
 case "$OCAML_PORT" in
   msvc) OCAML_TARGET=i686-pc-windows; OCAML_SYSTEM=win32;;
   msvc64) OCAML_TARGET=x86_64-pc-windows; OCAML_SYSTEM=win64;;

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,13 +30,13 @@ plug2.$(O): plug2.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(PLUG2_CFLAGS) -c plug2.c
 
 plug1.dll: plug1.$(O)
-	$(FLEXLINK) -o plug1.dll plug1.$(O)
+	$(FLEXLINK) $(addprefix -link ,$(LDFLAGS)) -o plug1.dll plug1.$(O)
 
 plug2.dll: plug2.$(O)
-	$(FLEXLINK) -o plug2.dll plug2.$(O)
+	$(FLEXLINK) $(addprefix -link ,$(LDFLAGS)) -o plug2.dll plug2.$(O)
 
 plug12.dll: plug1.$(O) plug2.$(O)
-	$(FLEXLINK) -o plug12.dll plug1.$(O) plug2.$(O)
+	$(FLEXLINK) $(addprefix -link ,$(LDFLAGS)) -o plug12.dll plug1.$(O) plug2.$(O)
 
 
 clean:


### PR DESCRIPTION
Four easy changes:
- Add testing for 5.4 and, for variety, test msvc64 by switch to the AppVeyor VS 2022 image
- Switch the trunk build to the VS 2022 image to fix [#164 (comment)](https://github.com/ocaml/flexdll/pull/164#issuecomment-3728911042)
- Switch 5.3 to test on MSVC as well (as the older 4.x images do)
- Add labels to the matrix items

Then the rabbit-hole:
- Deal with `safe.directory` 🥱
- Update the bootstraps to download FlexDLL 0.44, or [ocaml/ocaml#14034](https://github.com/ocaml/ocaml/pull/14034) will bite at some point!
- Actually activate the appropriate version of Visual Studio on the VS 2022 images!
- Update the i686 mingw demo to cope with mingw-w64 runtime 8.0.0+ (cf. [ocaml/ocaml#10046](https://github.com/ocaml/ocaml/pull/10046) - just hadn't noticed because the default AppVeyor image we use is intentionally old)
- Display a few more Cygwin package versions to confirm the previous diagnosis